### PR TITLE
Fix plugin import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ buildscript {
 }
 
 plugins {
-    id 'pl.allegro.tech.build.axion-gradle', version: '0.9.9'
+    id 'pl.allegro.tech.build.axion-release' version '0.9.9'
 }
 ```
 


### PR DESCRIPTION
Wrong plugin name and illegal comma and semicolon characters resulting:

```
   @ line 2, column 8.
         id "pl.allegro.tech.build.axion-gradle", version: "0.9.9"
            ^

  1 error
```
