### PR TITLE
Add Maven Central and JCenter badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ axion-release-plugin
 
 *gradle release and version management plugin*
 
-[![Build Status](https://travis-ci.org/allegro/axion-release-plugin.svg?branch=master)](https://travis-ci.org/allegro/axion-release-plugin)
+[![Build Status](https://travis-ci.org/allegro/axion-release-plugin.svg?branch=master)](https://travis-ci.org/allegro/axion-release-plugin) [![Maven Central](https://maven-badges.herokuapp.com/maven-central/pl.allegro.tech.build/axion-release-plugin/badge.svg?style=flat)](https://maven-badges.herokuapp.com/maven-central/pl.allegro.tech.build/axion-release-plugin) [![JCenter](https://api.bintray.com/packages/allegro/maven/axion-release-plugin/images/download.svg) ](https://bintray.com/allegro/maven/axion-release-plugin/_latestVersion)
 
 Releasing versions in Gradle is very different from releasing in Maven. Maven came with
 [maven-release-plugin](http://maven.apache.org/maven-release/maven-release-plugin/) which


### PR DESCRIPTION
To click on and get code snippet to put into Gradle/Maven build file.

Btw, there is no version in Bintray's badge. It looks ok, so I hope it will appear soon (it is probably better to wait for before merging that PR).
Btw2, I assume sync to Maven Central is still planned.