### PR TITLE
Issue #71: Ability to release pre-release versions like 2.0.0-rc1

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
@@ -55,6 +55,6 @@ class Releaser {
     }
 
     private boolean notOnTagAlready(VersionWithPosition positionedVersion) {
-        return positionedVersion.isSnapshotVersion
+        return positionedVersion.snapshotVersion
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
@@ -26,11 +26,7 @@ class Releaser {
         VersionWithPosition positionedVersion = versionConfig.getRawVersion()
         Version version = positionedVersion.version
 
-        if (notOnTagAlready(version)) {
-            version = new Version.Builder()
-                    .setNormalVersion(version.normalVersion)
-                    .setBuildMetadata(version.buildMetadata)
-                    .build()
+        if (notOnTagAlready(positionedVersion)) {
             String tagName = versionConfig.tag.serialize(versionConfig.tag, version.toString())
 
             if (versionConfig.createReleaseCommit) {
@@ -58,7 +54,7 @@ class Releaser {
 
     }
 
-    private boolean notOnTagAlready(Version version) {
-        return version.preReleaseVersion == VersionService.SNAPSHOT
+    private boolean notOnTagAlready(VersionWithPosition positionedVersion) {
+        return positionedVersion.isSnapshotVersion
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionService.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionService.groovy
@@ -20,11 +20,7 @@ class VersionService {
         VersionWithPosition positionedVersion = versionResolver.resolveVersion(versionConfig, options)
 
         if (!positionedVersion.position.onTag) {
-            positionedVersion = new VersionWithPosition(
-                    positionedVersion.version.setPreReleaseVersion(SNAPSHOT),
-                    positionedVersion.previousVersion,
-                    positionedVersion.position
-            )
+            positionedVersion.setSnapshotVersion(true)
         }
 
         return positionedVersion

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionService.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionService.groovy
@@ -20,7 +20,7 @@ class VersionService {
         VersionWithPosition positionedVersion = versionResolver.resolveVersion(versionConfig, options)
 
         if (!positionedVersion.position.onTag) {
-            positionedVersion.setSnapshotVersion(true)
+            positionedVersion.asSnapshotVersion()
         }
 
         return positionedVersion

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionWithPosition.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionWithPosition.groovy
@@ -11,7 +11,7 @@ class VersionWithPosition {
     
     final ScmPosition position
 
-    boolean isSnapshotVersion = false
+    boolean snapshotVersion = false
 
     VersionWithPosition(Version version, Version previousVersion, ScmPosition position) {
         this.version = version
@@ -27,7 +27,7 @@ class VersionWithPosition {
         return position == null
     }
 
-    void setSnapshotVersion(boolean isSnapshotVersion) {
-        this.isSnapshotVersion = isSnapshotVersion
+    void asSnapshotVersion() {
+        this.snapshotVersion = true
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionWithPosition.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionWithPosition.groovy
@@ -11,6 +11,8 @@ class VersionWithPosition {
     
     final ScmPosition position
 
+    boolean isSnapshotVersion = false
+
     VersionWithPosition(Version version, Version previousVersion, ScmPosition position) {
         this.version = version
         this.previousVersion = previousVersion
@@ -23,5 +25,9 @@ class VersionWithPosition {
 
     boolean forcedVersion() {
         return position == null
+    }
+
+    void setSnapshotVersion(boolean isSnapshotVersion) {
+        this.isSnapshotVersion = isSnapshotVersion
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
@@ -21,6 +21,6 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
         
         then:
         repository.currentPosition(~/.*/).latestTag == 'release-2.0.0-alpha'
-        versionService.currentVersion(config, VersionReadOptions.defaultOptions()).version.toString() == '2.0.0-SNAPSHOT'
+        versionService.currentDecoratedVersion(config, VersionReadOptions.defaultOptions()) == '2.0.0-SNAPSHOT'
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
@@ -38,6 +38,41 @@ class ReleaserTest extends RepositoryBasedTest {
         config.getVersion() == '1.0.0'
     }
 
+    def "should release with forced pre-released versions"() {
+        given:
+        project.extensions.extraProperties.set('release.forceVersion', '3.0.0-rc4')
+        config.createReleaseCommit = false
+
+        when:
+        releaser.release(config)
+
+        then:
+        config.getVersion() == '3.0.0-rc4'
+    }
+
+    def "should not release version when on pre-released version tag"() {
+        given:
+        repository.tag('release-3.0.0-rc4')
+
+        when:
+        releaser.release(config)
+
+        then:
+        config.getVersion() == '3.0.0-rc4'
+    }
+
+    def "should increment pre-released version correctly"() {
+        given:
+        repository.tag('release-3.0.0-rc4')
+        repository.commit(['*'], 'make is snapshot')
+
+        when:
+        releaser.release(config)
+
+        then:
+        config.getVersion() == '3.0.1'
+    }
+
     def "should create release commit if configured"() {
         given:
         project.extensions.extraProperties.set('release.forceVersion', '3.0.0')
@@ -50,4 +85,5 @@ class ReleaserTest extends RepositoryBasedTest {
         config.getVersion() == '3.0.0'
         repository.lastLogMessages(1) == ['release version: 3.0.0']
     }
+
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
@@ -36,7 +36,7 @@ class VersionServiceTest extends Specification {
 
         then:
         version.version.toString() == '1.0.0'
-        version.isSnapshotVersion == false
+        version.snapshotVersion == false
     }
 
     def "should return snapshot version with increased patch when not on tag"() {
@@ -52,7 +52,7 @@ class VersionServiceTest extends Specification {
 
         then:
         version.version.toString() == '1.0.1'
-        version.isSnapshotVersion == true
+        version.snapshotVersion == true
     }
 
     def "should sanitize version if flag is set to true"() {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
@@ -36,6 +36,7 @@ class VersionServiceTest extends Specification {
 
         then:
         version.version.toString() == '1.0.0'
+        version.isSnapshotVersion == false
     }
 
     def "should return snapshot version with increased patch when not on tag"() {
@@ -50,7 +51,8 @@ class VersionServiceTest extends Specification {
         VersionWithPosition version = service.currentVersion(versionConfig, readOptions)
 
         then:
-        version.version.toString() == '1.0.1-SNAPSHOT'
+        version.version.toString() == '1.0.1'
+        version.isSnapshotVersion == true
     }
 
     def "should sanitize version if flag is set to true"() {


### PR DESCRIPTION
Axion doesn't allow to release versions with pre-release suffixes like `2.0.0-rc1`. `gradle release -Prelease.forceVersion=2.0.0-rc2` releases 2.0.0 instead.