### PR TITLE
Always release if force version

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release.domain
 
 import com.github.zafarkhaja.semver.Version
+import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHooksRunner
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
@@ -15,18 +16,21 @@ class Releaser {
 
     private final Logger logger
 
-    Releaser(ScmService repository, ReleaseHooksRunner hooksRunner, LocalOnlyResolver localOnlyResolver, Logger logger) {
+    private Project project
+
+    Releaser(ScmService repository, ReleaseHooksRunner hooksRunner, LocalOnlyResolver localOnlyResolver, Project project) {
         this.repository = repository
         this.hooksRunner = hooksRunner
         this.localOnlyResolver = localOnlyResolver
-        this.logger = logger
+        this.project = project
+        this.logger = project.logger
     }
 
     void release(VersionConfig versionConfig) {
         VersionWithPosition positionedVersion = versionConfig.getRawVersion()
         Version version = positionedVersion.version
 
-        if (notOnTagAlready(positionedVersion)) {
+        if (notOnTagAlready(positionedVersion) || VersionReadOptions.fromProject(project).forceVersion) {
             String tagName = versionConfig.tag.serialize(versionConfig.tag, version.toString())
 
             if (versionConfig.createReleaseCommit) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
@@ -73,7 +73,7 @@ class Context {
                 scmService(),
                 new ReleaseHooksRunner(project.logger, scmService(), config().hooks),
                 localOnlyResolver(),
-                project.logger
+                project
         )
     }
     

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
@@ -13,7 +13,7 @@ class ReleaserTest extends RepositoryBasedTest {
         
         releaser = new Releaser(scmService, new ReleaseHooksRunner(project.logger, scmService, config.hooks),
                 context.localOnlyResolver(),
-                project.logger)
+                project)
     }
 
     def "should release new version when not on tag"() {
@@ -86,4 +86,17 @@ class ReleaserTest extends RepositoryBasedTest {
         repository.lastLogMessages(1) == ['release version: 3.0.0']
     }
 
+    def "should create release commit when on tag but forced"() {
+        given:
+        repository.tag('release-3.1.0')
+        project.extensions.extraProperties.set('release.forceVersion', '3.2.0')
+        config.createReleaseCommit = true
+
+        when:
+        releaser.release(config)
+
+        then:
+        config.getVersion() == '3.2.0'
+        repository.lastLogMessages(1) == ['release version: 3.2.0']
+    }
 }


### PR DESCRIPTION
PR for https://github.com/allegro/axion-release-plugin/issues/70

== copy from Issue ==
It's impossible to release forced version when:

- we are currently on released version but we want to release yet another version (say, we have many releasing branches and I want to release from the same position both 1.0.0 and 0.99.15)
- in case if something went wrong last time and axion already had created tag but later didn't managed to push changes to remote; and we want to re-release it again after we have fixed the issue

For cases like this it make sense to treat forceVersion option more strictly way - it should try to re-release the version if possible, even if we are already on released version.
