### PR TITLE
conditionalRelease task

### DIFF
--- a/docs/configuration/tasks.rst
+++ b/docs/configuration/tasks.rst
@@ -5,6 +5,7 @@ Tasks
 
 * *verifyRelease*
 * *release*
+* *conditionalRelease*
 * *createRelease*
 * *pushRelease*
 * *currentVersion*
@@ -23,6 +24,12 @@ of running *createRelease* and *pushRelease* in a single run. The crucial differ
 *release* task guarantees release & push operations will be called in single task run without other tasks interrupting.
 In case of calling *createRelease* and *pushRelease* via *dependsOn*, it is up to Gradle to create task execution
 graph, meaning there is no guarantee of these tasks running exactly one after another.
+
+conditionalRelease
+------------------
+
+Works exactly like the *release* task, but makes an addition comparison between the current scm branch to the configured
+release branch pattern before releasing. This can be useful in automatic continuous integration environments like Bamboo.
 
 createRelease
 -------------

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ConditionalReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ConditionalReleaseTask.groovy
@@ -1,0 +1,27 @@
+package pl.allegro.tech.build.axion.release
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.TaskAction
+import pl.allegro.tech.build.axion.release.domain.Releaser
+import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
+import pl.allegro.tech.build.axion.release.infrastructure.di.Context
+
+import java.util.regex.Pattern
+
+class ConditionalReleaseTask  extends DefaultTask {
+    String releaseBranch = "master"
+
+    @TaskAction
+    void conditionalRelease() {
+        println("Release branch is: " + releaseBranch)
+        Context context = new Context(project)
+        ScmRepository repository = context.repository()
+        def branch = repository.currentPosition(Pattern.compile(".*")).branch
+        if (branch == releaseBranch) {
+            Releaser releaser = context.releaser()
+
+            releaser.release(context.config())
+            releaser.pushRelease(context.config())
+        }
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ConditionalReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ConditionalReleaseTask.groovy
@@ -1,23 +1,20 @@
 package pl.allegro.tech.build.axion.release
-
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.Releaser
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 
-import java.util.regex.Pattern
-
 class ConditionalReleaseTask  extends DefaultTask {
     String releaseBranch = "master"
 
     @TaskAction
     void conditionalRelease() {
-        println("Release branch is: " + releaseBranch)
+        logger.info("Release branch pattern is: " + releaseBranch)
         Context context = new Context(project)
         ScmRepository repository = context.repository()
-        def branch = repository.currentPosition(Pattern.compile(".*")).branch
-        if (branch == releaseBranch) {
+        def branch = repository.currentPosition(~/.*/).branch
+        if (branch.matches(releaseBranch)) {
             Releaser releaser = context.releaser()
 
             releaser.release(context.config())

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -12,7 +12,9 @@ class ReleasePlugin implements Plugin<Project> {
     public static final String VERIFY_RELEASE_TASK = 'verifyRelease'
 
     public static final String RELEASE_TASK = 'release'
-    
+
+    public static final String CONDITIONAL_RELEASE_TASK = 'conditionalRelease'
+
     public static final String CREATE_RELEASE_TASK = 'createRelease'
     
     public static final String PUSH_RELEASE_TASK = 'pushRelease'
@@ -35,6 +37,11 @@ class ReleasePlugin implements Plugin<Project> {
         releaseTask.group = 'Release'
         releaseTask.description = 'Performs release - creates tag and pushes it to remote.'
         releaseTask.dependsOn(VERIFY_RELEASE_TASK)
+
+        Task conditionalReleaseTask = project.tasks.create(CONDITIONAL_RELEASE_TASK, ConditionalReleaseTask)
+        conditionalReleaseTask.group = 'Release'
+        conditionalReleaseTask.description = 'Performs conditional release - if the branch is "releaseBranch", creates a tag and pushes it to remote.'
+        conditionalReleaseTask.dependsOn(VERIFY_RELEASE_TASK)
 
         Task createReleaseTask = project.tasks.create(CREATE_RELEASE_TASK, CreateReleaseTask)
         createReleaseTask.group = 'Release'


### PR DESCRIPTION
I created a conditionalRelease task for automatic release detection during continuous integration builds - specifically on Bamboo where string comparison is impossible in scripts. The assumption is that everytime you commit to the "releaseBranch" you should have a release version created. This task can be safely executed on any branch, it will only actually release on the specified branch. Configuration is as simple as placing the following code in the build.gradle file:
``` groovy
conditionalRelease {
    releaseBranch = "production"
}
```