### PR TITLE
Provide a versionIncrementer called incrementMajor

### DIFF
--- a/docs/configuration/version.rst
+++ b/docs/configuration/version.rst
@@ -131,6 +131,7 @@ Incrementing phase does incrementing the version in accordance with *version inc
 
 * *incrementPatch* - increment patch number
 * *incrementMinor* - increment minor (middle) number
+* *incrementMajor* - increment major number
 * *incrementMinorIfNotOnRelease* - increment patch number if on release branch. Increment minor otherwise
 * *incrementPrerelease* - increment pre-release suffix if possible (-rc1 to -rc2). Increment patch otherwise
 * *branchSpecific* - call other incrementer based on branch name

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionIncrementer.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionIncrementer.groovy
@@ -15,6 +15,10 @@ enum PredefinedVersionIncrementer {
         return context.currentVersion.incrementMinorVersion()
     }),
 
+    INCREMENT_MAJOR('incrementMajor', { VersionIncrementerContext context, Map config ->
+        return context.currentVersion.incrementMajorVersion()
+    }),
+
     INCREMENT_MINOR_IF_NOT_ON_RELEASE_BRANCH('incrementMinorIfNotOnRelease', { VersionIncrementerContext context, Map config ->
         if(!config.releaseBranchPattern) {
             config.releaseBranchPattern = 'release/.+'

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionIncrementerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionIncrementerTest.groovy
@@ -20,6 +20,11 @@ class PredefinedVersionIncrementerTest extends Specification {
         versionIncrementerFor('incrementMinor')(context) == Version.valueOf('0.2.0')
     }
     
+    def "should increment major when incrementMajor rule used"() {
+        expect:
+        versionIncrementerFor('incrementMajor')(context) == Version.valueOf('1.0.0')
+    }
+
     def "should increment minor if not on release branch and incrementMinorIfNotOnRelease used"() {
         expect:
         versionIncrementerFor('incrementMinorIfNotOnRelease', [releaseBranchPattern: 'release.*'])(context) == Version.valueOf('0.2.0')


### PR DESCRIPTION
I have this usage model:
```
scmVersion {
  if (project.hasProperty('release.versionIncrementer')) {
    versionIncrementer project."release.versionIncrementer"
  }
}
```
I have added a PredefinedVersionIncrementer for the Major version, such that this command would work: ```./gradlew release -Prelease.versionIncrementer=incrementMajor```.

I do not know why a Major version incrementer is not part of the original plugin, I am new to this problem space.