### PR TITLE
remove project.logger dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ plugins {
 }
 
 apply plugin: 'com.gradle.plugin-publish'
+apply plugin: 'maven-publish'
 
 if(project.hasProperty('mavenCentral')) {
     apply from: 'gradle/mavenCentral.gradle'
@@ -101,5 +102,22 @@ pluginBundle {
     mavenCoordinates {
         groupId = 'pl.allegro.tech.build'
         artifactId = 'axion-release-plugin'
+    }
+}
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            from components.java
+        }
+    }
+}
+
+publishing {
+    repositories {
+        maven {
+            // change to point to your repo, e.g. http://my.org/repo
+            url "/Users/marcin.cylke/.m2/repo"
+        }
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseTask.groovy
@@ -2,6 +2,8 @@ package pl.allegro.tech.build.axion.release
 
 import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.TaskAction
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.ChecksResolver
 import pl.allegro.tech.build.axion.release.domain.LocalOnlyResolver
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
@@ -10,6 +12,8 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 
 class VerifyReleaseTask extends DefaultTask {
+
+    private final Logger logger = LoggerFactory.getLogger(VerifyReleaseTask)
 
     @TaskAction
     void prepare() {
@@ -25,7 +29,7 @@ class VerifyReleaseTask extends DefaultTask {
 
         if (resolver.checkUncommittedChanges()) {
             boolean uncommittedChanges = repository.checkUncommittedChanges()
-            project.logger.quiet("Looking for uncommitted changes.. ${uncommittedChanges ? 'FAILED' : ''}")
+            logger.trace("Looking for uncommitted changes.. ${uncommittedChanges ? 'FAILED' : ''}")
             if (uncommittedChanges && !dryRun) {
                 changesPrinter.printChanges()
 
@@ -33,18 +37,18 @@ class VerifyReleaseTask extends DefaultTask {
                         "See above for list of all changes.")
             }
         } else {
-            project.logger.quiet('Skipping uncommitted changes check')
+            logger.trace('Skipping uncommitted changes check')
         }
 
         boolean remoteAttached = repository.remoteAttached(config.repository.remote)
         if (resolver.checkAheadOfRemote() && !localOnlyResolver.localOnly(remoteAttached)) {
             boolean aheadOfRemote = repository.checkAheadOfRemote()
-            project.logger.quiet("Checking if branch is ahead of remote.. ${aheadOfRemote ? 'FAILED' : ''}")
+            logger.trace("Checking if branch is ahead of remote.. ${aheadOfRemote ? 'FAILED' : ''}")
             if (aheadOfRemote && !dryRun) {
                 throw new IllegalStateException("Current branch is ahead of remote counterpart - can't release.")
             }
         } else {
-            project.logger.quiet("Skipping ahead of remote check")
+            logger.trace("Skipping ahead of remote check")
         }
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarker.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarker.groovy
@@ -1,24 +1,24 @@
 package pl.allegro.tech.build.axion.release.domain
 
-import org.gradle.api.logging.Logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class NextVersionMarker {
 
+    private final Logger logger = LoggerFactory.getLogger(NextVersionMarker)
+
     private final ScmService repository
 
-    private final Logger logger
-
-    NextVersionMarker(ScmService repository, Logger logger) {
+    NextVersionMarker(ScmService repository) {
         this.repository = repository
-        this.logger = logger
     }
 
     void markNextVersion(VersionConfig versionConfig, String nextVersion) {
         String tagName = versionConfig.tag.serialize(versionConfig.tag, nextVersion)
         String nextVersionTag = versionConfig.nextVersion.serializer(versionConfig.nextVersion, tagName)
 
-        logger.quiet("Creating next version marker tag: $nextVersionTag")
+        logger.trace("Creating next version marker tag: $nextVersionTag")
         repository.tag(nextVersionTag)
         repository.push()
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionOptions.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionOptions.groovy
@@ -1,9 +1,12 @@
 package pl.allegro.tech.build.axion.release.domain
 
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 
 class NextVersionOptions {
+
+    private final static Logger logger = LoggerFactory.getLogger(NextVersionOptions)
 
     private static final String NEXT_VERSION_PROPERTY = "release.version"
 
@@ -16,7 +19,7 @@ class NextVersionOptions {
         this.nextVersion = nextVersion
     }
 
-    static NextVersionOptions fromProject(Project project, Logger logger) {
+    static NextVersionOptions fromProject(Project project) {
         String nextVersion = project.hasProperty(NEXT_VERSION_PROPERTY) ? project.property(NEXT_VERSION_PROPERTY) : null
         if(nextVersion == null && project.hasProperty(DEPRECATED_NEXT_VERSION_PROPERTY)) {
             logger.warn("Using deprecated parameter: $DEPRECATED_NEXT_VERSION_PROPERTY! Use $NEXT_VERSION_PROPERTY instead.")

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
@@ -2,17 +2,18 @@ package pl.allegro.tech.build.axion.release.domain
 
 import com.github.zafarkhaja.semver.Version
 import org.gradle.api.Project
-import org.gradle.api.logging.Logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHooksRunner
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class Releaser {
 
+    private final Logger logger = LoggerFactory.getLogger(ReleaseHooksRunner)
+
     private final ScmService repository
 
     private final ReleaseHooksRunner hooksRunner
-
-    private final Logger logger
 
     private Project project
 
@@ -20,7 +21,6 @@ class Releaser {
         this.repository = repository
         this.hooksRunner = hooksRunner
         this.project = project
-        this.logger = project.logger
     }
 
     void release(VersionConfig versionConfig) {
@@ -31,18 +31,18 @@ class Releaser {
             String tagName = versionConfig.tag.serialize(versionConfig.tag, version.toString())
 
             if (versionConfig.createReleaseCommit) {
-                logger.quiet("Creating release commit")
+                logger.trace("Creating release commit")
                 versionConfig.hooks.pre('commit', versionConfig.releaseCommitMessage)
             }
 
             hooksRunner.runPreReleaseHooks(positionedVersion, version)
 
-            logger.quiet("Creating tag: $tagName")
+            logger.trace("Creating tag: $tagName")
             repository.tag(tagName)
 
             hooksRunner.runPostReleaseHooks(positionedVersion, version)
         } else {
-            logger.quiet("Working on released version ${versionConfig.version}, nothing to release.")
+            logger.trace("Working on released version ${versionConfig.version}, nothing to release.")
         }
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/HookContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/HookContext.groovy
@@ -1,15 +1,16 @@
 package pl.allegro.tech.build.axion.release.domain.hooks
 
 import com.github.zafarkhaja.semver.Version
-import org.gradle.api.logging.Logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class HookContext {
-    
-    final Logger logger
-    
+
+    private final Logger logger = LoggerFactory.getLogger(HookContext)
+
     private final ScmService scmService
     
     final ScmPosition position
@@ -22,9 +23,8 @@ class HookContext {
     
     final List<String> patternsToCommit = []
     
-    HookContext(Logger logger, VersionConfig versionConfig, ScmService scmService,
+    HookContext(VersionConfig versionConfig, ScmService scmService,
                 ScmPosition position, Version previousVersion, Version currentVersion) {
-        this.logger = logger
         this.versionConfig = versionConfig
         this.scmService = scmService
         this.position = position

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunner.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunner.groovy
@@ -1,14 +1,11 @@
 package pl.allegro.tech.build.axion.release.domain.hooks
 
 import com.github.zafarkhaja.semver.Version
-import org.gradle.api.logging.Logger
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.domain.VersionWithPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class ReleaseHooksRunner {
-
-    private final Logger logger
 
     private final VersionConfig versionConfig
     
@@ -16,21 +13,20 @@ class ReleaseHooksRunner {
 
     private final HooksConfig hooksConfig
 
-    ReleaseHooksRunner(Logger logger, VersionConfig versionConfig, ScmService scmService, HooksConfig hooksConfig) {
-        this.logger = logger
+    ReleaseHooksRunner(VersionConfig versionConfig, ScmService scmService, HooksConfig hooksConfig) {
         this.versionConfig = versionConfig
         this.scmService = scmService
         this.hooksConfig = hooksConfig
     }
 
     void runPreReleaseHooks(VersionWithPosition versionWithPosition, Version releaseVersion) {
-        HookContext context = new HookContext(logger, versionConfig,  scmService,
+        HookContext context = new HookContext(versionConfig,  scmService,
                 versionWithPosition.position, versionWithPosition.previousVersion, releaseVersion)
         hooksConfig.preReleaseHooks.each { it.act(context) }
     }
 
     void runPostReleaseHooks(VersionWithPosition versionWithPosition, Version releaseVersion) {
-        HookContext context = new HookContext(logger, versionConfig, scmService,
+        HookContext context = new HookContext(versionConfig, scmService,
                 versionWithPosition.position, versionWithPosition.previousVersion, releaseVersion)
         hooksConfig.postReleaseHooks.each { it.act(context) }
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmInitializationOptions.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmInitializationOptions.groovy
@@ -12,9 +12,9 @@ class ScmInitializationOptions {
 
     final String remoteUrl
 
-    private static final String ATTACH_REMOTE_PROPERTY = 'release.attachRemote'
+    static final String ATTACH_REMOTE_PROPERTY = 'release.attachRemote'
 
-    private static final String FETCH_TAGS_PROPERTY = 'release.fetchTags'
+    static final String FETCH_TAGS_PROPERTY = 'release.fetchTags'
 
     ScmInitializationOptions(String remote, boolean fetchTags, boolean attachRemote, String remoteUrl) {
         this.remote = remote
@@ -23,12 +23,25 @@ class ScmInitializationOptions {
         this.remoteUrl = remoteUrl
     }
 
+    static Map<String, ?> extractParameters(Project project) {
+        return [ATTACH_REMOTE_PROPERTY : extractOptionalParameter(project, ATTACH_REMOTE_PROPERTY),
+                FETCH_TAGS_PROPERTY : extractOptionalParameter(project, FETCH_TAGS_PROPERTY)]
+    }
+
+    private static def extractOptionalParameter(Project project, String paramName) {
+        return (String) (project.hasProperty(paramName) ? project.property(paramName) : null)
+    }
+
     static ScmInitializationOptions fromProject(Project project, String remote) {
+        return fromProject(extractParameters(project), remote)
+    }
+
+    static ScmInitializationOptions fromProject(Map<String, ?> properties, String remote) {
         return new ScmInitializationOptions(
                 remote,
-                project.hasProperty(FETCH_TAGS_PROPERTY),
-                project.hasProperty(ATTACH_REMOTE_PROPERTY),
-                (String) (project.hasProperty(ATTACH_REMOTE_PROPERTY) ? project.property(ATTACH_REMOTE_PROPERTY) : null)
+                properties.containsKey(FETCH_TAGS_PROPERTY),
+                properties.containsKey(ATTACH_REMOTE_PROPERTY),
+                (String) (properties.containsKey(ATTACH_REMOTE_PROPERTY) ? properties.get(ATTACH_REMOTE_PROPERTY) : null)
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmInitializationOptions.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmInitializationOptions.groovy
@@ -12,9 +12,9 @@ class ScmInitializationOptions {
 
     final String remoteUrl
 
-    static final String ATTACH_REMOTE_PROPERTY = 'release.attachRemote'
+    private static final String ATTACH_REMOTE_PROPERTY = 'release.attachRemote'
 
-    static final String FETCH_TAGS_PROPERTY = 'release.fetchTags'
+    private static final String FETCH_TAGS_PROPERTY = 'release.fetchTags'
 
     ScmInitializationOptions(String remote, boolean fetchTags, boolean attachRemote, String remoteUrl) {
         this.remote = remote

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release.infrastructure
 
-import org.gradle.api.logging.Logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
@@ -11,12 +12,11 @@ import java.util.regex.Pattern
 class DryRepository implements ScmRepository {
     
     private final ScmRepository delegateRepository
-    
-    private final Logger logger
 
-    DryRepository(ScmRepository delegateRepository, Logger logger) {
+    private final Logger logger = LoggerFactory.getLogger(DryRepository)
+
+    DryRepository(ScmRepository delegateRepository) {
         this.delegateRepository = delegateRepository
-        this.logger = logger
     }
 
     @Override
@@ -82,6 +82,6 @@ class DryRepository implements ScmRepository {
     }
 
     private void log(String msg) {
-        logger.quiet("DRY-RUN: $msg")
+        logger.trace("DRY-RUN: $msg")
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -11,7 +11,7 @@ import java.util.regex.Pattern
 
 class DummyRepository implements ScmRepository {
 
-    private final Logger logger = LoggerFactory.getLogger(DummyRepository.getClass())
+    private final Logger logger = LoggerFactory.getLogger(DummyRepository)
 
     private void log(String commandName) {
         logger.quiet("Couldn't perform $commandName command on uninitialized repository")

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release.infrastructure
 
-import org.gradle.api.logging.Logger
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
@@ -10,12 +11,8 @@ import java.util.regex.Pattern
 
 class DummyRepository implements ScmRepository {
 
-    private final Logger logger
+    private final Logger logger = LoggerFactory.getLogger(DummyRepository.getClass())
 
-    DummyRepository(Logger logger) {
-        this.logger = logger
-    }
-    
     private void log(String commandName) {
         logger.quiet("Couldn't perform $commandName command on uninitialized repository")
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/GradleAwareScmService.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/GradleAwareScmService.groovy
@@ -1,6 +1,8 @@
 package pl.allegro.tech.build.axion.release.infrastructure
 
 import org.gradle.api.Project
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.LocalOnlyResolver
 import pl.allegro.tech.build.axion.release.domain.RepositoryConfig
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentityResolver
@@ -9,6 +11,8 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class GradleAwareScmService implements ScmService {
+
+    private final Logger logger = LoggerFactory.getLogger(GradleAwareScmService)
 
     private final LocalOnlyResolver localOnlyResolver
 
@@ -33,13 +37,13 @@ class GradleAwareScmService implements ScmService {
     @Override
     void push() {
         if (!localOnlyResolver.localOnly(this.remoteAttached())) {
-            project.logger.quiet("Pushing all to remote: ${config.remote}")
+            logger.trace("Pushing all to remote: ${config.remote}")
             repository.push(
                     ScmIdentityResolver.resolve(config),
                     ScmPushOptions.fromProject(project, config)
             )
         } else {
-            project.logger.quiet("Changes made to local repository only")
+            logger.trace("Changes made to local repository only")
         }
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
@@ -12,6 +12,7 @@ import pl.allegro.tech.build.axion.release.domain.VersionResolver
 import pl.allegro.tech.build.axion.release.domain.VersionService
 import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHooksRunner
 import pl.allegro.tech.build.axion.release.domain.scm.ScmChangesPrinter
+import pl.allegro.tech.build.axion.release.domain.scm.ScmInitializationOptions
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 import pl.allegro.tech.build.axion.release.infrastructure.GradleAwareScmService
@@ -32,7 +33,7 @@ class Context {
 
     private void initialize(Project project) {
         instances[VersionFactory] = new VersionFactory()
-        instances[ScmRepository] = new ScmRepositoryFactory().create(project, config().repository)
+        instances[ScmRepository] = new ScmRepositoryFactory().create(ScmInitializationOptions.extractParameters(project), config().repository)
         instances[VersionService] = new VersionService(new VersionResolver(get(ScmRepository), get(VersionFactory)))
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
@@ -46,7 +46,7 @@ class Context {
     }
 
     ScmRepository repository() {
-        return config().dryRun ? new DryRepository(get(ScmRepository), project.logger) : get(ScmRepository)
+        return config().dryRun ? new DryRepository(get(ScmRepository)) : get(ScmRepository)
     }
 
     ScmService scmService() {
@@ -72,7 +72,7 @@ class Context {
     Releaser releaser() {
         return new Releaser(
                 scmService(),
-                new ReleaseHooksRunner(project.logger, config(), scmService(), config().hooks),
+                new ReleaseHooksRunner(config(), scmService(), config().hooks),
                 project
         )
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactory.groovy
@@ -10,24 +10,29 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmRepositoryUnavailableEx
 import pl.allegro.tech.build.axion.release.infrastructure.DummyRepository
 import pl.allegro.tech.build.axion.release.infrastructure.git.GitRepository
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 class ScmRepositoryFactory {
 
     private static final String GIT = 'git'
 
-    ScmRepository create(Project project, RepositoryConfig config) {
+    private final Logger logger = LoggerFactory.getLogger(ScmRepositoryFactory.getClass())
+
+    ScmRepository create(Map<String, ?> properties, RepositoryConfig config) {
         if(config.type != GIT) {
             throw new IllegalArgumentException("Unsupported repository type $config.type")
         }
 
         ScmRepository repository
         try {
-            ScmInitializationOptions initializationOptions = ScmInitializationOptions.fromProject(project, config.remote)
+            ScmInitializationOptions initializationOptions = ScmInitializationOptions.fromProject(properties, config.remote)
             ScmIdentity identity = ScmIdentityResolver.resolve(config)
-            repository = new GitRepository(config.directory, identity, initializationOptions, project.logger)
+            repository = new GitRepository(config.directory, identity, initializationOptions)
         }
         catch(ScmRepositoryUnavailableException exception) {
-            project.logger.warn('Failed top open repository, trying to work without it', exception)
-            repository = new DummyRepository(project.logger)
+            logger.warn('Failed top open repository, trying to work without it', exception)
+            repository = new DummyRepository()
         }
 
         return repository

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactory.groovy
@@ -17,7 +17,7 @@ class ScmRepositoryFactory {
 
     private static final String GIT = 'git'
 
-    private final Logger logger = LoggerFactory.getLogger(ScmRepositoryFactory.getClass())
+    private final Logger logger = LoggerFactory.getLogger(ScmRepositoryFactory)
 
     ScmRepository create(Map<String, ?> properties, RepositoryConfig config) {
         if(config.type != GIT) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -14,14 +14,15 @@ import org.eclipse.jgit.revwalk.RevCommit
 import org.eclipse.jgit.revwalk.RevSort
 import org.eclipse.jgit.revwalk.RevWalk
 import org.eclipse.jgit.transport.*
-import org.gradle.api.logging.Logger
+import org.slf4j.LoggerFactory
 import pl.allegro.tech.build.axion.release.domain.scm.*
+import org.slf4j.Logger
 
 import java.util.regex.Pattern
 
 class GitRepository implements ScmRepository {
 
-    private final Logger log;
+    private final Logger log = LoggerFactory.getLogger(GitRepository.getClass())
 
     private static final String GIT_TAG_PREFIX = 'refs/tags/'
 
@@ -31,8 +32,7 @@ class GitRepository implements ScmRepository {
     
     private final Grgit repository
 
-    GitRepository(File repositoryDir, ScmIdentity identity, ScmInitializationOptions options, Logger logger) {
-        this.log = logger;
+    GitRepository(File repositoryDir, ScmIdentity identity, ScmInitializationOptions options) {
         try {
             this.repositoryDir = repositoryDir
             repository = Grgit.open(dir: repositoryDir)
@@ -184,11 +184,11 @@ class GitRepository implements ScmRepository {
     }
 
     private boolean hasCommits() {
-        LogCommand log = repository.repository.jgit.log()
-        log.maxCount = 1
+        LogCommand logCommand = repository.repository.jgit.log()
+        logCommand.maxCount = 1
 
         try {
-            log.call()
+            logCommand.call()
             return true
         }
         catch(NoHeadException exception) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -22,7 +22,7 @@ import java.util.regex.Pattern
 
 class GitRepository implements ScmRepository {
 
-    private final Logger log = LoggerFactory.getLogger(GitRepository.getClass())
+    private final Logger log = LoggerFactory.getLogger(GitRepository)
 
     private static final String GIT_TAG_PREFIX = 'refs/tags/'
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
@@ -12,7 +12,7 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
         repository = context.repository()
         versionService = context.versionService()
 
-        nextVersionMarker = new NextVersionMarker(context.scmService(), project.logger)
+        nextVersionMarker = new NextVersionMarker(context.scmService())
     }
     
     def "should create next version tag with given version"() {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionOptionsTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionOptionsTest.groovy
@@ -18,7 +18,7 @@ class NextVersionOptionsTest extends Specification {
         project.extensions.extraProperties.set('release.version', '1.0.0')
 
         when:
-        NextVersionOptions options = NextVersionOptions.fromProject(project, project.logger)
+        NextVersionOptions options = NextVersionOptions.fromProject(project)
 
         then:
         options.nextVersion
@@ -30,7 +30,7 @@ class NextVersionOptionsTest extends Specification {
         project.extensions.extraProperties.set('release.nextVersion', '1.0.0')
 
         when:
-        NextVersionOptions options = NextVersionOptions.fromProject(project, project.logger)
+        NextVersionOptions options = NextVersionOptions.fromProject(project)
 
         then:
         options.nextVersion
@@ -39,7 +39,7 @@ class NextVersionOptionsTest extends Specification {
 
     def "should throw exception when no 'release.version' property present"() {
         when:
-        NextVersionOptions.fromProject(project, project.logger)
+        NextVersionOptions.fromProject(project)
 
         then:
         thrown(IllegalArgumentException)

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
@@ -11,7 +11,7 @@ class ReleaserTest extends RepositoryBasedTest {
     def setup() {
         ScmService scmService = context.scmService()
         
-        releaser = new Releaser(scmService, new ReleaseHooksRunner(project.logger, config, scmService, config.hooks), project)
+        releaser = new Releaser(scmService, new ReleaseHooksRunner(config, scmService, config.hooks), project)
     }
 
     def "should release new version when not on tag"() {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/HookContextBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/HookContextBuilder.groovy
@@ -17,7 +17,7 @@ class HookContextBuilder {
     String currentVersion = '2.0.0'
     
     HookContext build() {
-        return new HookContext({} as Logger, null, scmService, position,
+        return new HookContext(null, scmService, position,
                 new Version.Builder().setNormalVersion(previousVersion).build(),
                 new Version.Builder().setNormalVersion(currentVersion).build())
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunnerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunnerTest.groovy
@@ -9,7 +9,7 @@ class ReleaseHooksRunnerTest extends Specification {
     
     private HooksConfig config = new HooksConfig()
     
-    private ReleaseHooksRunner runner = new ReleaseHooksRunner(null, null, null, config)
+    private ReleaseHooksRunner runner = new ReleaseHooksRunner(null, null, config)
     
     private VersionWithPosition version = new VersionWithPosition(
             new Version.Builder().setNormalVersion('2.0.0-SNAPSHOT').build(),

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactoryTest.groovy
@@ -4,6 +4,7 @@ import org.ajoberstar.grgit.Grgit
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import pl.allegro.tech.build.axion.release.domain.RepositoryConfig
+import pl.allegro.tech.build.axion.release.domain.scm.ScmInitializationOptions
 import pl.allegro.tech.build.axion.release.infrastructure.DummyRepository
 import pl.allegro.tech.build.axion.release.infrastructure.git.GitRepository
 import spock.lang.Specification
@@ -25,7 +26,7 @@ class ScmRepositoryFactoryTest extends Specification {
 
     def "should return git repository by default"() {
         expect:
-        factory.create(project, config) instanceof GitRepository
+        factory.create(ScmInitializationOptions.extractParameters(project), config) instanceof GitRepository
     }
 
     def "should return dummy repository when underlying repository is not initialized"() {
@@ -34,7 +35,7 @@ class ScmRepositoryFactoryTest extends Specification {
         config.directory = gitlessProject.rootDir
 
         expect:
-        factory.create(gitlessProject, config) instanceof DummyRepository
+        factory.create(ScmInitializationOptions.extractParameters(gitlessProject), config) instanceof DummyRepository
     }
 
     def "should throw exception when trying to construct unknown type of repository"() {
@@ -42,7 +43,7 @@ class ScmRepositoryFactoryTest extends Specification {
         config.type = 'unknown'
 
         when:
-        factory.create(project, config)
+        factory.create(ScmInitializationOptions.extractParameters(project), config)
 
         then:
         thrown(IllegalArgumentException)

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
@@ -1,6 +1,5 @@
 package pl.allegro.tech.build.axion.release.infrastructure.git
 
-import org.gradle.api.logging.Logger
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
@@ -12,9 +11,7 @@ class DryRepositoryTest extends Specification {
 
     ScmRepository scm = Mock()
 
-    Logger logger = Mock()
-
-    DryRepository dryRepository = new DryRepository(scm, logger)
+    DryRepository dryRepository = new DryRepository(scm)
 
     def "should not create actual tags in scm"() {
         when:

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
@@ -66,7 +66,7 @@ class GitProjectBuilder {
     Map build() {
         Map map = [:]
         map[Grgit] = rawRepository
-        map[GitRepository] = new GitRepository(repositoryDir, identity, initializationOptions, project.logger)
+        map[GitRepository] = new GitRepository(repositoryDir, identity, initializationOptions)
         
         return map
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -44,7 +44,7 @@ class GitRepositoryTest extends Specification {
         Project gitlessProject = ProjectBuilder.builder().build()
 
         when:
-        new GitRepository(gitlessProject.file('./'), identity, initializationOptions, project.logger)
+        new GitRepository(gitlessProject.file('./'), identity, initializationOptions)
 
         then:
         thrown(ScmRepositoryUnavailableException)


### PR DESCRIPTION
I'd like to use code from this plugin in SBT build, but with Gradle Project references all over the place I just can't do this.

As a solution I've removed dependencies on `project.logger` in favour of Slf4j's Logger - as described here: https://docs.gradle.org/current/userguide/logging.html#sec:sending_your_own_log_messages

