### PR TITLE
Tag selector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,12 @@
 *.ipr
 *.iws
 
+# Eclipse project files
+.classpath
+.project
+.settings/
+bin/
+
 # gradle config
 .gradle
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializationConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializationConfig.groovy
@@ -2,6 +2,7 @@ package pl.allegro.tech.build.axion.release.domain
 
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
+import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository;
 
 class TagNameSerializationConfig {
 
@@ -20,10 +21,16 @@ class TagNameSerializationConfig {
     Closure deserialize = TagNameSerializer.DEFAULT.deserializer
 
     Closure initialVersion = defaultInitialVersion()
+	
+	Closure tagSelector = defaultTagSelector()
 
     private static Closure defaultInitialVersion() {
         return { TagProperties rules, ScmPosition position ->
             return '0.1.0'
         }
     }
+	
+	private static Closure defaultTagSelector() {
+		return ScmRepository.LAST_TAG_SELECTOR
+	}
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -8,16 +8,16 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 
 class VersionResolver {
-    
+
     private final ScmRepository repository
 
     private final VersionFactory versionFactory
-    
+
     VersionResolver(ScmRepository repository, VersionFactory versionFactory) {
         this.repository = repository
         this.versionFactory = versionFactory
     }
-    
+
     VersionWithPosition resolveVersion(VersionProperties versionRules, TagProperties tagRules, NextVersionProperties nextVersionRules) {
         Map positions = readPositions(tagRules, nextVersionRules)
 
@@ -29,27 +29,27 @@ class VersionResolver {
         if(positions.currentPosition.nextVersionTag) {
             position = position.asNotOnTagPosition()
         }
-        
+
         return new VersionWithPosition(currentVersion, previousVersion, position)
     }
 
 
     private Map readPositions(TagProperties tagRules, NextVersionProperties nextVersionRules) {
-        ScmPosition currentPosition = repository.currentPosition(~/^${tagRules.prefix}.*(|${nextVersionRules.suffix})$/)
+        ScmPosition currentPosition = repository.currentPosition(~/^${tagRules.prefix}.*(|${nextVersionRules.suffix})$/, tagRules.tagSelector)
         ScmPositionContext currentPositionContext = new ScmPositionContext(currentPosition, nextVersionRules)
 
         ScmPosition lastReleasePosition
         if(currentPositionContext.nextVersionTag) {
-            lastReleasePosition = repository.currentPosition(~/^${tagRules.prefix}.*/, ~/.*${nextVersionRules.suffix}$/).asOnTagPosition()
+            lastReleasePosition = repository.currentPosition(~/^${tagRules.prefix}.*/, ~/.*${nextVersionRules.suffix}$/, tagRules.tagSelector).asOnTagPosition()
         }
         else {
             lastReleasePosition = currentPosition.asOnTagPosition()
         }
-        
+
         return [
                 currentPosition: currentPositionContext,
                 lastReleasePosition: new ScmPositionContext(lastReleasePosition, nextVersionRules)
         ]
     }
-    
+
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagProperties.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagProperties.groovy
@@ -15,4 +15,6 @@ class TagProperties {
 
     final Closure<String> initialVersion
 
+    final Closure<String> tagSelector
+
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
@@ -2,7 +2,12 @@ package pl.allegro.tech.build.axion.release.domain.scm
 
 import java.util.regex.Pattern
 
+import groovy.lang.Closure;
+
 interface ScmRepository {
+    public static final Closure<String> LAST_TAG_SELECTOR = { List<String> tags ->
+        tags && tags.size() > 0 ? tags[-1] : null
+    }
 
     void fetchTags(ScmIdentity identity, String remoteName)
 
@@ -17,8 +22,10 @@ interface ScmRepository {
     String currentBranch()
 
     ScmPosition currentPosition(Pattern tagPattern)
-    
-    ScmPosition currentPosition(Pattern tagPattern, Pattern inversePattern)
+
+    ScmPosition currentPosition(Pattern tagPattern, Closure<String> tagSelector)
+
+    ScmPosition currentPosition(Pattern tagPattern, Pattern inversePattern, Closure<String> tagSelector)
 
     boolean remoteAttached(String remoteName);
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -9,7 +9,7 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import java.util.regex.Pattern
 
 class DryRepository implements ScmRepository {
-    
+
     private static final ReleaseLogger logger = ReleaseLogger.Factory.logger(DryRepository)
 
     private final ScmRepository delegateRepository
@@ -50,15 +50,20 @@ class DryRepository implements ScmRepository {
     }
 
     @Override
-    ScmPosition currentPosition(Pattern tagPattern, Pattern inversePattern) {
-        return currentPosition(tagPattern)
-    }
-    
-    @Override
-    ScmPosition currentPosition(Pattern tagPattern) {
-        ScmPosition position = delegateRepository.currentPosition(tagPattern)
+    ScmPosition currentPosition(Pattern tagPattern, Closure<String> tagSelector) {
+        ScmPosition position = delegateRepository.currentPosition(tagPattern, tagSelector)
         log("scm position: $position")
         return position
+    }
+
+    @Override
+    ScmPosition currentPosition(Pattern tagPattern, Pattern inversePattern, Closure<String> tagSelector) {
+        return currentPosition(tagPattern, tagSelector)
+    }
+
+    @Override
+    ScmPosition currentPosition(Pattern tagPattern) {
+        return currentPosition(tagPattern, LAST_TAG_SELECTOR)
     }
 
     @Override

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -14,7 +14,7 @@ class DummyRepository implements ScmRepository {
 
     DummyRepository() {
     }
-    
+
     private void log(String commandName) {
         logger.quiet("Couldn't perform $commandName command on uninitialized repository")
     }
@@ -54,9 +54,14 @@ class DummyRepository implements ScmRepository {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
         return ScmPosition.defaultPosition()
     }
-    
+
     @Override
-    ScmPosition currentPosition(Pattern tagPattern, Pattern inversePattern) {
+    ScmPosition currentPosition(Pattern tagPattern, Closure tagSelector) {
+        return currentPosition(tagPattern)
+    }
+
+    @Override
+    ScmPosition currentPosition(Pattern tagPattern, Pattern inversePattern, Closure tagSelector) {
         return currentPosition(tagPattern)
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/TagPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/TagPropertiesFactory.groovy
@@ -14,7 +14,7 @@ class TagPropertiesFactory {
                 serialize: config.serialize,
                 deserialize: config.deserialize,
                 initialVersion: config.initialVersion,
-				tagSelector: config.tagSelector
+                tagSelector: config.tagSelector
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/TagPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/TagPropertiesFactory.groovy
@@ -13,7 +13,8 @@ class TagPropertiesFactory {
                 versionSeparator: config.versionSeparator,
                 serialize: config.serialize,
                 deserialize: config.deserialize,
-                initialVersion: config.initialVersion
+                initialVersion: config.initialVersion,
+				tagSelector: config.tagSelector
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -32,9 +32,9 @@ class GitRepository implements ScmRepository {
     private static final String GIT_TAG_PREFIX = 'refs/tags/'
 
     private final TransportConfigFactory transportConfigFactory = new TransportConfigFactory()
-    
+
     private final File repositoryDir
-    
+
     private final Grgit repository
 
     private final ScmProperties properties
@@ -159,38 +159,50 @@ class GitRepository implements ScmRepository {
 
     @Override
     ScmPosition currentPosition(Pattern pattern) {
-        return currentPosition(pattern, Pattern.compile('$a^'))
+        return currentPosition(pattern, Pattern.compile('$a^'), LAST_TAG_SELECTOR)
     }
-    
+
     @Override
-    ScmPosition currentPosition(Pattern pattern, Pattern inversePattern) {
+    ScmPosition currentPosition(Pattern pattern, Closure<String> tagSelector) {
+        return currentPosition(pattern, Pattern.compile('$a^'), tagSelector)
+    }
+
+    @Override
+    ScmPosition currentPosition(Pattern pattern, Pattern inversePattern, Closure<String> tagSelector) {
         if(!hasCommits()) {
             return ScmPosition.defaultPosition()
         }
 
         Map tags = repository.tag.list()
                 .grep({ def tag = it.fullName.substring(GIT_TAG_PREFIX.length()); tag ==~ pattern && !(tag ==~ inversePattern) })
-                .inject([:], { map, entry -> map[entry.commit.id] = entry.fullName.substring(GIT_TAG_PREFIX.length()); return map; })
+                .inject([:], { map, entry ->
+                    if (map[entry.commit.id] == null) {
+                        map[entry.commit.id] = [] as List<String>
+                    }
+                    map[entry.commit.id] << entry.fullName.substring(GIT_TAG_PREFIX.length())
+                    return map
+                })
 
         ObjectId headId = repository.repository.jgit.repository.resolve(Constants.HEAD)
         String branch = repository.branch.current.name
 
         RevWalk walk = new RevWalk(repository.repository.jgit.repository)
         walk.sort(RevSort.TOPO)
+        walk.sort(RevSort.COMMIT_TIME_DESC, true)
         RevCommit head = walk.parseCommit(headId)
 
-        String tagName = null
+        List<String> tagNameList = null
 
         walk.markStart(head)
         RevCommit commit
         for (commit = walk.next(); commit != null; commit = walk.next()) {
-            tagName = tags[commit.id.name()]
-            if (tagName != null) {
+            tagNameList = tags[commit.id.name()]
+            if (tagNameList != null) {
                 break
             }
         }
         walk.dispose()
-
+        String tagName = tagSelector(tagNameList)
         boolean onTag = (commit == null) ? null : commit.id.name() == headId.name()
         return new ScmPosition(branch, tagName, onTag, checkUncommittedChanges())
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -175,10 +175,7 @@ class GitRepository implements ScmRepository {
 
         Map tags = repository.tag.list()
                 .grep({ def tag = it.fullName.substring(GIT_TAG_PREFIX.length()); tag ==~ pattern && !(tag ==~ inversePattern) })
-                .inject([:], { map, entry ->
-                    if (map[entry.commit.id] == null) {
-                        map[entry.commit.id] = [] as List<String>
-                    }
+                .inject([:].withDefault {p -> []}, { map, entry ->
                     map[entry.commit.id] << entry.fullName.substring(GIT_TAG_PREFIX.length())
                     return map
                 })
@@ -197,7 +194,7 @@ class GitRepository implements ScmRepository {
         RevCommit commit
         for (commit = walk.next(); commit != null; commit = walk.next()) {
             tagNameList = tags[commit.id.name()]
-            if (tagNameList != null) {
+            if (tagNameList) {
                 break
             }
         }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagPropertiesBuilder.groovy
@@ -19,7 +19,7 @@ class TagPropertiesBuilder {
                 prefix: 'release',
                 versionSeparator: '-',
                 initialVersion: { r, p -> '0.1.0' },
-				tagSelector: ScmRepository.LAST_TAG_SELECTOR
+                tagSelector: ScmRepository.LAST_TAG_SELECTOR
         )
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagPropertiesBuilder.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release.domain.properties
 
 import pl.allegro.tech.build.axion.release.domain.TagNameSerializer
+import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository;
 
 class TagPropertiesBuilder {
 
@@ -17,7 +18,8 @@ class TagPropertiesBuilder {
                 deserialize: TagNameSerializer.DEFAULT.deserializer,
                 prefix: 'release',
                 versionSeparator: '-',
-                initialVersion: { r, p -> '0.1.0' }
+                initialVersion: { r, p -> '0.1.0' },
+				tagSelector: ScmRepository.LAST_TAG_SELECTOR
         )
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
@@ -40,7 +40,7 @@ class DryRepositoryTest extends Specification {
     def "should return currentPosition from real scm"() {
         given:
         ScmPosition expectedPosition = new ScmPosition("master", "latest", true)
-        scm.currentPosition(_) >> expectedPosition
+        scm.currentPosition(_, _) >> expectedPosition
 
         when:
         ScmPosition currentPosition = dryRepository.currentPosition(~/^release.*/)


### PR DESCRIPTION
Added support for a "tagSelector" closure in tag configuration, which is called to select among multiple tags on the same commit. Defaults back to selecting the last tag in the list of tags returned from scm (same behaviour as before). This allows to resolve #139 (see also discussion in #135).