### PR TITLE
Add EditorConfig configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,10 @@
+# EditorConfig: http://EditorConfig.org
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true


### PR DESCRIPTION
To address @vbuell's comment in the recent [PR](https://github.com/allegro/axion-release-plugin/pull/178#pullrequestreview-25897851).

We had similar problem with formatting in PRs in our projects and [EditorConfig](http://editorconfig.org/) helped in simple scenarios (such as spaces vs tabs). It is supported out-of-box by Idea and some other IDEs/editors with support in several more available as plugins.