### PR TITLE
Fixes error when working on project without Git repository

### DIFF
--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/RepositorylessIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/RepositorylessIntegrationTest.groovy
@@ -1,0 +1,41 @@
+package pl.allegro.tech.build.axion.release
+
+import org.gradle.testkit.runner.GradleRunner
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.Rule
+import org.junit.rules.TemporaryFolder
+import spock.lang.Specification
+
+class RepositorylessIntegrationTest extends Specification {
+
+    @Rule
+    TemporaryFolder temporaryFolder = new TemporaryFolder()
+
+    File directory
+
+    void setup() {
+        directory = temporaryFolder.root
+    }
+
+    def "should not fail build when calling currentVersion task on project without repo"() {
+        given:
+        File build = temporaryFolder.newFile('build.gradle')
+        build << """
+        plugins {
+            id 'pl.allegro.tech.build.axion-release'
+        }
+
+        project.version = scmVersion.version
+        """
+
+        when:
+        def result = GradleRunner.create()
+            .withProjectDir(directory)
+            .withPluginClasspath()
+            .withArguments('currentVersion', '-s')
+            .build()
+
+        then:
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -48,13 +48,11 @@ class VersionResolver {
     private Map readVersions(VersionFactory versionFactory,
                              TagProperties tagProperties,
                              NextVersionProperties nextVersionProperties) {
-        GitRepository repository = (GitRepository) this.repository
         Pattern releaseTagPattern = ~/^${tagProperties.prefix}.*/
         Pattern nextVersionTagPattern = ~/.*${nextVersionProperties.suffix}$/
 
-        Map currentVersionInfo = null
-        Map previousVersionInfo = null
-        List<TagsOnCommit> allTaggedCommits = repository.firstTaggedCommitAsList(releaseTagPattern)
+        Map currentVersionInfo, previousVersionInfo
+        List<TagsOnCommit> allTaggedCommits = [repository.latestTags(releaseTagPattern)]
         currentVersionInfo = versionFromTaggedCommits(allTaggedCommits, false, nextVersionTagPattern, versionFactory)
 
         TagsOnCommit previousTags = repository.latestTags(releaseTagPattern)
@@ -77,13 +75,10 @@ class VersionResolver {
     private Map readVersionsByHighestVersion(VersionFactory versionFactory,
                                               TagProperties tagProperties,
                                              NextVersionProperties nextVersionProperties) {
-        GitRepository repository = (GitRepository) this.repository
         Pattern releaseTagPattern = ~/^${tagProperties.prefix}.*/
         Pattern nextVersionTagPattern = ~/.*${nextVersionProperties.suffix}$/
 
-        Map currentVersionInfo = null
-        Map previousVersionInfo = null
-
+        Map currentVersionInfo, previousVersionInfo
         List<TagsOnCommit> allTaggedCommits = repository.taggedCommits(releaseTagPattern)
 
         currentVersionInfo = versionFromTaggedCommits(allTaggedCommits, false, nextVersionTagPattern, versionFactory)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
@@ -20,6 +20,8 @@ interface ScmRepository {
 
     TagsOnCommit latestTags(Pattern pattern, String sinceCommit)
 
+    List<TagsOnCommit> taggedCommits(Pattern pattern)
+
     boolean remoteAttached(String remoteName);
 
     boolean checkUncommittedChanges()

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -65,6 +65,11 @@ class DryRepository implements ScmRepository {
     }
 
     @Override
+    List<TagsOnCommit> taggedCommits(Pattern pattern) {
+        return delegateRepository.taggedCommits(pattern)
+    }
+
+    @Override
     boolean remoteAttached(String remoteName) {
         return true
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -62,6 +62,12 @@ class DummyRepository implements ScmRepository {
         return new TagsOnCommit(null, [], false)
     }
 
+    @Override
+    List<TagsOnCommit> taggedCommits(Pattern pattern) {
+        logger.quiet("Could not resolve current position on uninitialized repository, returning default")
+        return [new TagsOnCommit(null, [], false)]
+    }
+
 
     @Override
     boolean remoteAttached(String remoteName) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -169,10 +169,12 @@ class GitRepository implements ScmRepository {
         )
     }
 
+    @Override
     TagsOnCommit latestTags(Pattern pattern) {
         return latestTagsInternal(pattern, null, true)
     }
 
+    @Override
     TagsOnCommit latestTags(Pattern pattern, String sinceCommit) {
         return latestTagsInternal(pattern, sinceCommit, false)
     }
@@ -182,10 +184,7 @@ class GitRepository implements ScmRepository {
         return taggedCommits.isEmpty() ? TagsOnCommit.empty() : taggedCommits[0]
     }
 
-    List<TagsOnCommit> firstTaggedCommitAsList(Pattern pattern) {
-        return taggedCommitsInternal(pattern, null, true, true)
-    }
-
+    @Override
     List<TagsOnCommit> taggedCommits(Pattern pattern) {
         return taggedCommitsInternal(pattern, null, true, false)
     }


### PR DESCRIPTION
I noticed that one of previous PRs introduced casting to `GitRepository` instead of using methods exposed in `ScmRepository`, which caused build to fail with `ClassCastException`. However there was no test for this behaviour before. Now the test has been added and problem is fixed. Parts of code in `VersionResolver` are still due for refactoring in the future.

Fixes #186 