### PR TITLE
Adding optional VersionConfig to each task

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/CreateReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/CreateReleaseTask.groovy
@@ -1,18 +1,23 @@
 package pl.allegro.tech.build.axion.release
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.Releaser
+import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
 class CreateReleaseTask extends DefaultTask {
 
+    @Optional
+    VersionConfig versionConfig
+
     @TaskAction
     void release() {
-        Context context = GradleAwareContext.create(project)
+        Context context = versionConfig == null ? GradleAwareContext.create(project) : GradleAwareContext.create(project, versionConfig)
         Releaser releaser = context.releaser()
         releaser.release(context.rules())
     }
-    
+
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/MarkNextVersionTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/MarkNextVersionTask.groovy
@@ -1,17 +1,22 @@
 package pl.allegro.tech.build.axion.release
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.NextVersionMarker
+import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.domain.properties.Properties
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
 class MarkNextVersionTask extends DefaultTask {
 
+    @Optional
+    VersionConfig versionConfig
+
     @TaskAction
     void release() {
-        Context context = GradleAwareContext.create(project)
+        Context context = versionConfig == null ? GradleAwareContext.create(project) : GradleAwareContext.create(project, versionConfig)
 
         NextVersionMarker marker = new NextVersionMarker(context.scmService())
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/OutputCurrentVersionTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/OutputCurrentVersionTask.groovy
@@ -1,11 +1,15 @@
 package pl.allegro.tech.build.axion.release
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.infrastructure.output.OutputWriter
 
 class OutputCurrentVersionTask extends DefaultTask {
+
+    @Optional
+    VersionConfig versionConfig
 
     OutputCurrentVersionTask() {
         this.outputs.upToDateWhen { false }
@@ -13,16 +17,18 @@ class OutputCurrentVersionTask extends DefaultTask {
 
     @TaskAction
     void output() {
-        VersionConfig versionConfig = project.extensions.getByType(VersionConfig)
-
         boolean quiet = project.hasProperty('release.quiet')
-        String outputContent = versionConfig.version
+        String outputContent = resolveVersionConfig().version
         if (!quiet) {
             outputContent = '\nProject version: ' + outputContent
         }
 
         OutputWriter output = new OutputWriter()
         output.println(outputContent)
+    }
+
+    def resolveVersionConfig() {
+        return this.versionConfig == null ? project.extensions.getByType(VersionConfig) : this.versionConfig
     }
 
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/PushReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/PushReleaseTask.groovy
@@ -1,19 +1,24 @@
 package pl.allegro.tech.build.axion.release
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.Releaser
+import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
 class PushReleaseTask extends DefaultTask {
 
+    @Optional
+    VersionConfig versionConfig
+
     @TaskAction
     void release() {
-        Context context = GradleAwareContext.create(project)
-        
+        Context context = versionConfig == null ? GradleAwareContext.create(project) : GradleAwareContext.create(project, versionConfig)
+
         Releaser releaser = context.releaser()
         releaser.pushRelease()
     }
-    
+
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -12,9 +12,9 @@ class ReleasePlugin implements Plugin<Project> {
     public static final String VERIFY_RELEASE_TASK = 'verifyRelease'
 
     public static final String RELEASE_TASK = 'release'
-    
+
     public static final String CREATE_RELEASE_TASK = 'createRelease'
-    
+
     public static final String PUSH_RELEASE_TASK = 'pushRelease'
 
     public static final String MARK_NEXT_VERSION_TASK = 'markNextVersion'

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseTask.groovy
@@ -1,16 +1,21 @@
 package pl.allegro.tech.build.axion.release
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.Releaser
+import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
 class ReleaseTask extends DefaultTask {
 
+    @Optional
+    VersionConfig versionConfig
+
     @TaskAction
     void release() {
-        Context context = GradleAwareContext.create(project)
+        Context context = versionConfig == null ? GradleAwareContext.create(project) : GradleAwareContext.create(project, versionConfig)
         Releaser releaser = context.releaser()
 
         releaser.release(context.rules())

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseTask.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.LocalOnlyResolver
 import pl.allegro.tech.build.axion.release.domain.SnapshotDependenciesChecker
@@ -13,9 +14,12 @@ import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
 class VerifyReleaseTask extends DefaultTask {
 
+    @Optional
+    VersionConfig versionConfig
+
     @TaskAction
     void verify() {
-        Context context = GradleAwareContext.create(project)
+        Context context = versionConfig == null ? GradleAwareContext.create(project) : GradleAwareContext.create(project, versionConfig)
 
         ScmRepository repository = context.repository()
         ScmChangesPrinter changesPrinter = context.changesPrinter()

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
@@ -10,17 +10,15 @@ import pl.allegro.tech.build.axion.release.infrastructure.config.ScmPropertiesFa
 
 class GradleAwareContext {
 
-    static Context create(Project project) {
-        VersionConfig config = config(project)
-
-        ScmProperties scmProperties = ScmPropertiesFactory.create(project, config)
+    static Context create(Project project, VersionConfig versionConfig = config(project)) {
+        ScmProperties scmProperties = ScmPropertiesFactory.create(project, versionConfig)
         ScmRepository scmRepository = ScmRepositoryFactory.create(scmProperties)
 
         return new Context(
-                RulesFactory.create(project, config, scmRepository.currentPosition()),
+                RulesFactory.create(project, versionConfig, scmRepository.currentPosition()),
                 scmRepository,
                 scmProperties,
-                LocalOnlyResolverFactory.create(project, config)
+                LocalOnlyResolverFactory.create(project, versionConfig)
         )
     }
 


### PR DESCRIPTION
At the moment, the tasks in the plugin cannot be reused without applying the entire plugin, since they rely on the `VersionConfig` extension.

In this pull request, I add an `Optional` `VersionConfig` input to each task so that other plugins can use a single task, or a subset of them, and set the `VersionConfig` directly for each task.

What I'm trying to enable here is something like the following.
```groovy
def exampleTask = project.tasks.create('exampleTask', ReleaseTask)
exampleTask.group = 'example'
exampleTask.description = 'Does example things...'
exampleTask.configure {
    versionConfig = new VersionConfig(project)
    versionConfig.versionIncrementer 'incrementMajor'
    // .. etc
}
exampleTask.doFirst {
    // .. stuff
}
```