### PR TITLE
Fixes silently ignoring push failure while leaving created tag intact (#203)

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseTask.groovy
@@ -19,9 +19,7 @@ class ReleaseTask extends DefaultTask {
         VersionConfig config = GradleAwareContext.configOrCreateFromProject(project, versionConfig)
         Context context = GradleAwareContext.create(project, config)
         Releaser releaser = context.releaser()
-
-        releaser.release(context.rules())
-        releaser.pushRelease()
+        releaser.releaseAndPush(context.rules())
     }
 
     void setVersionConfig(VersionConfig versionConfig) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunner.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunner.groovy
@@ -1,16 +1,13 @@
 package pl.allegro.tech.build.axion.release.domain.hooks
 
 import com.github.zafarkhaja.semver.Version
-import pl.allegro.tech.build.axion.release.domain.VersionService
 import pl.allegro.tech.build.axion.release.domain.VersionContext
-import pl.allegro.tech.build.axion.release.domain.logging.ReleaseLogger
+import pl.allegro.tech.build.axion.release.domain.VersionService
 import pl.allegro.tech.build.axion.release.domain.properties.HooksProperties
 import pl.allegro.tech.build.axion.release.domain.properties.Properties
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class ReleaseHooksRunner {
-
-    private static final ReleaseLogger logger = ReleaseLogger.Factory.logger(ReleaseHooksRunner)
 
     private final VersionService versionService
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmException.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmException.groovy
@@ -1,0 +1,12 @@
+package pl.allegro.tech.build.axion.release.domain.scm
+
+class ScmException extends RuntimeException {
+
+    ScmException(Throwable cause) {
+        super(cause)
+    }
+
+    ScmException(String message) {
+        super(message)
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
@@ -8,6 +8,8 @@ interface ScmRepository {
 
     void tag(String tagName)
 
+    void dropTag(String tagName)
+
     void push(ScmIdentity identity, ScmPushOptions pushOptions)
 
     void commit(List patterns, String message)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmService.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmService.groovy
@@ -23,12 +23,27 @@ class ScmService {
         repository.tag(tagName)
     }
 
+    void dropTag(String tagName) {
+        try {
+            repository.dropTag(tagName)
+        } catch (ScmException e) {
+            logger.quiet("Exception occurred during removing the tag: ${e.message}")
+            throw e
+        }
+    }
+
     void push() {
-        if (!localOnlyResolver.localOnly(this.remoteAttached())) {
+        if (localOnlyResolver.localOnly(this.remoteAttached())) {
+            logger.quiet("Changes made to local repository only")
+            return
+        }
+
+        try {
             logger.quiet("Pushing all to remote: ${scmProperties.remote}")
             repository.push(scmProperties.identity, scmProperties.pushOptions())
-        } else {
-            logger.quiet("Changes made to local repository only")
+        } catch (ScmException e) {
+            logger.quiet("Exception occurred during push: ${e.message}")
+            throw e
         }
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -21,13 +21,18 @@ class DryRepository implements ScmRepository {
 
     @Override
     void fetchTags(ScmIdentity identity, String remoteName) {
-        log('fetching tags from remote')
+        log("fetching tags from remote")
         delegateRepository.fetchTags(identity, remoteName)
     }
 
     @Override
     void tag(String tagName) {
         log("creating tag with name: $tagName")
+    }
+
+    @Override
+    void dropTag(String tagName) {
+        log("dropping tag with name: $tagName")
     }
 
     @Override

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -31,6 +31,11 @@ class DummyRepository implements ScmRepository {
     }
 
     @Override
+    void dropTag(String tagName) {
+        log('drop tag')
+    }
+
+    @Override
     void push(ScmIdentity identity, ScmPushOptions pushOptions) {
         log('push')
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
@@ -1,7 +1,6 @@
 package pl.allegro.tech.build.axion.release.infrastructure.git
 
 import org.ajoberstar.grgit.Grgit
-import org.gradle.api.Project
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilder


### PR DESCRIPTION
During release task a new tag is created and then a push is attempted. However, if said push fails due to remote-side validation, the task still ends as a success while leaving the created tag. This creates the inconsistent state.

After applying this fix the task will fail with exception received from the remote during push and the tag will be removed (if it was created). This solves the issue #203 