### PR TITLE
Changes forceVersion not to force -SNAPSHOT when forced version same as current

### DIFF
--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
@@ -48,6 +48,18 @@ class SimpleIntegrationTest extends BaseIntegrationTest {
         result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
     }
 
+    def "should force returned version with -Prelease.forceVersion flag"() {
+        given:
+        buildFile('')
+
+        when:
+        def result = runGradle('currentVersion', '-Prelease.forceVersion=2.0.0')
+
+        then:
+        result.output.contains('Project version: 2.0.0-SNAPSHOT')
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
+
     def "should update file in pre release hook"() {
         given:
         File versionFile = newFile('version-file')

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactory.groovy
@@ -49,7 +49,11 @@ class VersionFactory {
         boolean hasCommittedChanges = !scmState.onReleaseTag
         boolean hasChanges = hasCommittedChanges || hasUncommittedChanges
 
-        boolean isSnapshot = versionProperties.forcedVersion || versionProperties.forceSnapshot || hasChanges || scmState.onNextVersionTag || scmState.noReleaseTagsFound
+        boolean forcesSameVersionAsCurrent = versionProperties.forceVersion() &&
+            versionProperties.forcedVersion == version.toString()
+        boolean forceVersionShouldForceSnapshot = versionProperties.forceVersion() && !forcesSameVersionAsCurrent
+
+        boolean isSnapshot = forceVersionShouldForceSnapshot || versionProperties.forceSnapshot || hasChanges || scmState.onNextVersionTag || scmState.noReleaseTagsFound
         boolean incrementVersion = versionProperties.forceSnapshot || (!scmState.onNextVersionTag && !scmState.noReleaseTagsFound && hasChanges)
 
         Version finalVersion = version

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactoryTest.groovy
@@ -74,6 +74,30 @@ class VersionFactoryTest extends Specification {
         version.snapshot
     }
 
+    def "should return forced snapshot version when forcing is on and already on tag"() {
+        given:
+        VersionFactory factory = versionFactory(versionProperties().forceVersion('1.5.0').build())
+
+        when:
+        Map version = factory.createFinalVersion(scmState().onReleaseTag().build(), Version.valueOf('1.0.0'))
+
+        then:
+        version.version.toString() == '1.5.0'
+        version.snapshot
+    }
+
+    def "should return forced version without snapshot when forcing same version as current tag"() {
+        given:
+        VersionFactory factory = versionFactory(versionProperties().forceVersion('1.5.0').build())
+
+        when:
+        Map version = factory.createFinalVersion(scmState().onReleaseTag().build(), Version.valueOf('1.5.0'))
+
+        then:
+        version.version.toString() == '1.5.0'
+        !version.snapshot
+    }
+
     def "should not increment patch version when being on position after next version tag"() {
         when:
         Map version = factory.createFinalVersion(scmState().onNextVersionTag().build(), Version.valueOf('1.0.0'))


### PR DESCRIPTION
Should fix #208 

When running -Prelease.forceVersion on tagged commit, current version is
checked. If current version == -Prelease.forceVersion, no -SNAPSHOT is added.
In other case, -SNAPSHOT is added (no change in behaviour).