### PR TITLE
Tests for remote push rejection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: required
 
 language: java
 
@@ -8,3 +8,6 @@ after_success: ./gradlew jacocoTestReport coveralls
 
 jdk:
   - oraclejdk8
+
+services:
+  - docker

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'io.codearte.nexus-staging' version '0.5.3' apply false
 
     id 'me.champeau.gradle.jmh' version '0.4.3'
+    id 'com.bmuschko.docker-remote-api' version '3.2.1'
 }
 
 if (project.hasProperty('mavenCentral')) {
@@ -39,7 +40,7 @@ repositories {
 }
 
 project.ext.versions = [
-        jgit: '4.5.2.201704071617-r'
+        jgit: '4.9.0.201710071750-r'
 ]
 
 sourceSets {
@@ -56,13 +57,29 @@ sourceSets {
                 project.configurations.testRuntime
         runtimeClasspath = output + compileClasspath
     }
+
+    remoteTest {
+        java.srcDir project.file('src/test-remote/java')
+        groovy.srcDir project.file('src/test-remote/groovy')
+
+        resources.srcDir project.file('src/test-remote/resources')
+        resources.srcDir project.sourceSets.test.resources
+        resources.srcDir project.sourceSets.main.resources
+
+        compileClasspath = project.sourceSets.main.output +
+            project.sourceSets.test.output +
+            project.configurations.testRuntime
+        runtimeClasspath = output + compileClasspath
+    }
 }
 
 dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile group: 'org.ajoberstar', name: 'grgit', version: '1.7.2'
+    compile (group: 'org.ajoberstar', name: 'grgit', version: '1.7.2') {
+        exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit.ui'
+    }
 
     compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: versions.jgit
     compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.ui', version: versions.jgit
@@ -75,6 +92,8 @@ dependencies {
     }
     testCompile group: 'cglib', name: 'cglib-nodep', version: '3.1'
     testCompile group: 'org.objenesis', name: 'objenesis', version: '2.4'
+    testCompile group: 'org.apache.sshd', name: 'sshd-core', version: '1.6.0'
+    testCompile group: 'org.apache.sshd', name: 'sshd-git', version: '1.6.0'
 
     testCompile gradleTestKit()
 }
@@ -93,6 +112,13 @@ project.configurations {
         transitive = true
         visible = true
     }
+
+    remoteTest {
+        extendsFrom project.configurations.testRuntime
+        description = 'Dependencies for tests with Docker'
+        transitive = true
+        visible = true
+    }
 }
 
 task integrationTest(type: Test) {
@@ -107,6 +133,44 @@ task integrationTest(type: Test) {
         events 'passed', 'skipped', 'failed'
         exceptionFormat = 'full'
     }
+}
+
+task buildDockerImage(type: com.bmuschko.gradle.docker.tasks.image.DockerBuildImage) {
+    inputDir = file('docker')
+    tag = 'test/axion-release-remote:latest'
+}
+
+task createDockerContainer(type: com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer) {
+    dependsOn buildDockerImage
+    targetImageId { buildDockerImage.getImageId() }
+    portBindings = ['2222:22']
+}
+
+task startDockerContainer(type: com.bmuschko.gradle.docker.tasks.container.DockerStartContainer) {
+    dependsOn createDockerContainer
+    targetContainerId { createDockerContainer.getContainerId() }
+}
+
+task stopDockerContainer(type: com.bmuschko.gradle.docker.tasks.container.DockerStopContainer) {
+    targetContainerId { createDockerContainer.getContainerId() }
+}
+
+
+task remoteTest(type: Test) {
+    testClassesDirs = project.sourceSets.remoteTest.output.classesDirs
+    classpath = project.sourceSets.main.output +
+        project.sourceSets.test.output +
+        project.sourceSets.remoteTest.runtimeClasspath +
+        project.configurations.testRuntime +
+        project.configurations.remoteTestRuntime
+
+    testLogging {
+        events 'passed', 'skipped', 'failed'
+        exceptionFormat = 'full'
+    }
+
+    dependsOn startDockerContainer
+    finalizedBy stopDockerContainer
 }
 
 tasks.check.dependsOn integrationTest

--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,7 @@ task remoteTest(type: Test) {
     finalizedBy stopDockerContainer
 }
 
-tasks.check.dependsOn integrationTest
+tasks.check.dependsOn integrationTest, remoteTest
 
 jmh {
     benchmarkMode = ['ss']

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven'
     id 'jacoco'
-    id 'pl.allegro.tech.build.axion-release' version '1.7.1'
+    id 'pl.allegro.tech.build.axion-release' version '1.8.1'
     id 'com.github.kt3k.coveralls' version '2.3.1'
     id 'com.gradle.plugin-publish' version '0.9.8'
     id 'com.bmuschko.nexus' version '2.3.1' apply false

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,13 @@
+FROM jkarlos/git-server-docker
+
+RUN passwd -d git \
+  && sed -i 's/^PasswordAuthentication.*/PasswordAuthentication yes/g' /etc/ssh/sshd_config \
+  && echo "PermitEmptyPasswords yes" >> /etc/ssh/sshd_config \
+  && ls /etc/init.d \
+  && mkdir -p repos \
+  && git init --bare repos/rejecting-repo \
+  && echo -e "#!/bin/sh\necho 'I reject this push!' >&2\nexit 1" > repos/rejecting-repo/hooks/pre-receive \
+  && chmod +x repos/rejecting-repo/hooks/pre-receive \
+  && sh /etc/init.d/sshd restart
+
+CMD ["sh", "start.sh"]

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
@@ -63,7 +63,7 @@ class SimpleIntegrationTest extends BaseIntegrationTest {
         """)
 
         when:
-        runGradle('release', '-Prelease.version=1.0.0', '-Prelease.localOnly', '-Prelease.disableChecks')
+        runGradle('release', '-Prelease.version=1.0.0', '-Prelease.localOnly', '-Prelease.disableChecks', '-s')
 
         then:
         versionFile.text == "Version: 1.0.0"

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/PushReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/PushReleaseTask.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.Releaser
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
@@ -19,7 +20,12 @@ class PushReleaseTask extends DefaultTask {
         Context context = GradleAwareContext.create(project, config)
 
         Releaser releaser = context.releaser()
-        releaser.pushRelease()
+        ScmPushResult result = releaser.pushRelease()
+
+        if(!result.success) {
+            logger.error("remote message: ${result.remoteMessage}")
+            throw new ReleaseFailedException(result.remoteMessage)
+        }
     }
 
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseFailedException.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseFailedException.groovy
@@ -1,0 +1,12 @@
+package pl.allegro.tech.build.axion.release
+
+class ReleaseFailedException extends RuntimeException {
+
+    ReleaseFailedException(String message) {
+        super(message)
+    }
+
+    @Override
+    Throwable fillInStackTrace() {
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/Releaser.groovy
@@ -4,7 +4,7 @@ import com.github.zafarkhaja.semver.Version
 import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHooksRunner
 import pl.allegro.tech.build.axion.release.domain.logging.ReleaseLogger
 import pl.allegro.tech.build.axion.release.domain.properties.Properties
-import pl.allegro.tech.build.axion.release.domain.scm.ScmException
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class Releaser {
@@ -43,19 +43,19 @@ class Releaser {
         }
     }
 
-    void releaseAndPush(Properties rules) {
+    ScmPushResult releaseAndPush(Properties rules) {
         Optional<String> releasedTagName = release(rules)
 
-        try {
-            pushRelease()
-        } catch (ScmException e) {
+        ScmPushResult result = pushRelease()
+
+        if (!result.success) {
             releasedTagName.ifPresent { rollbackRelease(it) }
-            throw e
         }
+        return result
     }
 
-    void pushRelease() {
-        repository.push()
+    ScmPushResult pushRelease() {
+        return repository.push()
     }
 
     private void rollbackRelease(String tagName) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPushResult.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPushResult.groovy
@@ -1,0 +1,13 @@
+package pl.allegro.tech.build.axion.release.domain.scm
+
+class ScmPushResult {
+
+    final boolean success
+
+    final Optional<String> remoteMessage
+
+    ScmPushResult(boolean success, Optional<String> remoteMessage) {
+        this.success = success
+        this.remoteMessage = remoteMessage
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
@@ -10,7 +10,7 @@ interface ScmRepository {
 
     void dropTag(String tagName)
 
-    void push(ScmIdentity identity, ScmPushOptions pushOptions)
+    ScmPushResult push(ScmIdentity identity, ScmPushOptions pushOptions)
 
     void commit(List patterns, String message)
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmService.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmService.groovy
@@ -32,15 +32,15 @@ class ScmService {
         }
     }
 
-    void push() {
+    ScmPushResult push() {
         if (localOnlyResolver.localOnly(this.remoteAttached())) {
             logger.quiet("Changes made to local repository only")
-            return
+            return new ScmPushResult(true, Optional.empty())
         }
 
         try {
             logger.quiet("Pushing all to remote: ${scmProperties.remote}")
-            repository.push(scmProperties.identity, scmProperties.pushOptions())
+            return repository.push(scmProperties.identity, scmProperties.pushOptions())
         } catch (ScmException e) {
             logger.quiet("Exception occurred during push: ${e.message}")
             throw e

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -4,6 +4,7 @@ import pl.allegro.tech.build.axion.release.domain.logging.ReleaseLogger
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
 
@@ -36,8 +37,9 @@ class DryRepository implements ScmRepository {
     }
 
     @Override
-    void push(ScmIdentity identity, ScmPushOptions pushOptions) {
+    ScmPushResult push(ScmIdentity identity, ScmPushOptions pushOptions) {
         log("pushing to remote: ${pushOptions.remote}")
+        return new ScmPushResult(true, Optional.empty())
     }
 
     @Override

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -4,6 +4,7 @@ import pl.allegro.tech.build.axion.release.domain.logging.ReleaseLogger
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
 
@@ -36,8 +37,9 @@ class DummyRepository implements ScmRepository {
     }
 
     @Override
-    void push(ScmIdentity identity, ScmPushOptions pushOptions) {
+    ScmPushResult push(ScmIdentity identity, ScmPushOptions pushOptions) {
         log('push')
+        return new ScmPushResult(true, Optional.empty())
     }
 
     @Override

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/SshConnector.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/SshConnector.groovy
@@ -20,7 +20,7 @@ class SshConnector extends JschConfigSessionFactory {
 
     @Override
     protected void configure(OpenSshConfig.Host hc, Session session) {
-        session.setConfig("StrictHostKeyChecking", "no");
+        session.setConfig("StrictHostKeyChecking", "no")
     }
 
     @Override
@@ -34,8 +34,10 @@ class SshConnector extends JschConfigSessionFactory {
 
     private JSch createJSch() {
         JSch jsch = new JSch()
-        byte[] passPhrase = identity.passPhrase != null ? identity.passPhrase.bytes : null
-        jsch.addIdentity('key', identity.privateKey.bytes, null, passPhrase)
+        if(!identity.useDefault) {
+            byte[] passPhrase = identity.passPhrase != null ? identity.passPhrase.bytes : null
+            jsch.addIdentity('key', identity.privateKey.bytes, null, passPhrase)
+        }
 
         return jsch
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/TransportConfigFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/TransportConfigFactory.groovy
@@ -12,8 +12,22 @@ class TransportConfigFactory {
             return createForSsh(identity)
         } else if (identity.usernameBased) {
             return createForUsername(identity)
+        } else if(identity.useDefault) {
+            return createForDefault(identity)
         }
-        throw new IllegalArgumentException("Transport callback can be created only for private key or username based identity")
+        throw new IllegalArgumentException("Transport callback can be created only for none (empty), private key or username based identity")
+    }
+
+    private TransportConfigCallback createForDefault(ScmIdentity identity) {
+        return new TransportConfigCallback() {
+            @Override
+            void configure(Transport transport) {
+                if(transport instanceof SshTransport) {
+                    SshTransport sshTransport = (SshTransport) transport
+                    sshTransport.setSshSessionFactory(new SshConnector(identity))
+                }
+            }
+        }
     }
 
     private TransportConfigCallback createForSsh(ScmIdentity identity) {

--- a/src/test-remote/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
+++ b/src/test-remote/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
@@ -8,6 +8,7 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmException
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilder
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult
 import pl.allegro.tech.build.axion.release.infrastructure.git.GitRepository
 import pl.allegro.tech.build.axion.release.infrastructure.git.SshConnector
 import spock.lang.Specification
@@ -40,10 +41,11 @@ class RemoteRejectionTest extends Specification {
         repository.commit(['*'], 'commit after release-custom')
 
         when:
-        repository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions(remote: 'origin', pushTagsOnly: false), true)
+        ScmPushResult result = repository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions(remote: 'origin', pushTagsOnly: false), true)
 
         then:
-        thrown(ScmException)
+        !result.success
+        result.remoteMessage.get().contains("I reject this push!")
     }
 
 }

--- a/src/test-remote/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
+++ b/src/test-remote/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
@@ -1,0 +1,49 @@
+package pl.allegro.tech.build.axion.release
+
+import org.eclipse.jgit.api.Git
+import org.eclipse.jgit.api.TransportConfigCallback
+import org.eclipse.jgit.transport.SshTransport
+import org.eclipse.jgit.transport.Transport
+import pl.allegro.tech.build.axion.release.domain.scm.ScmException
+import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilder
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
+import pl.allegro.tech.build.axion.release.infrastructure.git.GitRepository
+import pl.allegro.tech.build.axion.release.infrastructure.git.SshConnector
+import spock.lang.Specification
+
+class RemoteRejectionTest extends Specification {
+
+    // defined in Docker run script in build.gradle
+    private static final int SSH_PORT = 2222
+
+    def "should return error on push failure"() {
+        given:
+        File repoDir = File.createTempDir('axion-release', 'tmp')
+
+        Git.cloneRepository()
+            .setDirectory(repoDir)
+            .setTransportConfigCallback(new TransportConfigCallback() {
+            @Override
+            void configure(Transport transport) {
+                SshTransport sshTransport = (SshTransport) transport
+                sshTransport.setSshSessionFactory(new SshConnector(ScmIdentity.defaultIdentity()))
+            }
+        })
+            .setURI("ssh://git@localhost:${SSH_PORT}/git-server/repos/rejecting-repo")
+            .call()
+
+        GitRepository repository = new GitRepository(ScmPropertiesBuilder.scmProperties(repoDir).build())
+
+        repository.commit(['*'], 'initial commit')
+        repository.tag('release-custom')
+        repository.commit(['*'], 'commit after release-custom')
+
+        when:
+        repository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions(remote: 'origin', pushTagsOnly: false), true)
+
+        then:
+        thrown(ScmException)
+    }
+
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
@@ -26,7 +26,7 @@ class GitProjectBuilder {
     private GitProjectBuilder(File project, File cloneFrom) {
         this.repositoryDir = project
 
-        this.rawRepository =  Grgit.clone(dir: repositoryDir, uri: "file://${cloneFrom.canonicalPath}")
+        this.rawRepository = Grgit.clone(dir: repositoryDir, uri: "file://${cloneFrom.canonicalPath}")
         this.scmProperties = ScmPropertiesBuilder.scmProperties(repositoryDir).build()
         this.identity = ScmIdentity.defaultIdentity()
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -275,4 +275,9 @@ class GitRepositoryTest extends Specification {
         remoteRawRepository.log(maxCommits: 1)*.fullMessage == ['InitialCommit']
         remoteRawRepository.tag.list()*.fullName == []
     }
+
+    def "should return error on push failure"() {
+        expect: 'this test is implemented as part of testRemote suite in RemoteRejectionTest'
+        true
+    }
 }


### PR DESCRIPTION
Docker-based tests for remote push rejection. Due to the deficiencies of jgit hooks implementation (lack of pre-receive support), those tests could not be emulated in java.

Tests which require docker are isolated in `remoteTest` target. They require running docker demon. Creation of image and running the container are automated. `remoteTest` is also part of `check` target.