### PR TITLE
#211 use default JSch when using default ScmIdentity instead of new JSch

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/SshConnector.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/SshConnector.groovy
@@ -26,7 +26,7 @@ class SshConnector extends JschConfigSessionFactory {
     @Override
     protected JSch getJSch(OpenSshConfig.Host hc, FS fs) throws JSchException {
         if(this.jsch == null) {
-            this.jsch = createJSch()
+            this.jsch = (!identity.useDefault) ? createJSch() : super.getJSch(hc, fs)
         }
 
         return this.jsch
@@ -34,11 +34,8 @@ class SshConnector extends JschConfigSessionFactory {
 
     private JSch createJSch() {
         JSch jsch = new JSch()
-        if(!identity.useDefault) {
-            byte[] passPhrase = identity.passPhrase != null ? identity.passPhrase.bytes : null
-            jsch.addIdentity('key', identity.privateKey.bytes, null, passPhrase)
-        }
-
+        byte[] passPhrase = identity.passPhrase != null ? identity.passPhrase.bytes : null
+        jsch.addIdentity('key', identity.privateKey.bytes, null, passPhrase)
         return jsch
     }
 }


### PR DESCRIPTION
Fixes #211.
The call to `super.getJSch(hc, fs)` creates a default JSch with the known hosts and identities in the ~/.ssh dir on the file system. Using just `new JSch()` creates an empty JSch and therefore causes the Auth fail when using the default ScmIdentity.