### PR TITLE
Another jgit grgit update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven'
     id 'jacoco'
-    id 'pl.allegro.tech.build.axion-release' version '1.8.1'
+    id 'pl.allegro.tech.build.axion-release' version '1.8.2'
     id 'com.github.kt3k.coveralls' version '2.3.1'
     id 'com.gradle.plugin-publish' version '0.9.8'
     id 'com.bmuschko.nexus' version '2.3.1' apply false
@@ -33,14 +33,15 @@ scmVersion {
 group = 'pl.allegro.tech.build'
 version = scmVersion.version
 
-sourceCompatibility = '1.7'
+sourceCompatibility = '1.8'
 
 repositories {
+	jcenter()
     mavenCentral()
 }
 
 project.ext.versions = [
-        jgit: '4.9.0.201710071750-r'
+        jgit: '4.10.0.201712302008-r'
 ]
 
 sourceSets {
@@ -77,7 +78,7 @@ dependencies {
     compile gradleApi()
     compile localGroovy()
 
-    compile (group: 'org.ajoberstar', name: 'grgit', version: '1.7.2') {
+    compile (group: 'org.ajoberstar', name: 'grgit', version: '2.1.0') {
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit.ui'
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -304,7 +304,7 @@ class GitRepository implements ScmRepository {
 
     @Override
     boolean checkAheadOfRemote() {
-        BranchStatus status = repository.branch.status(branch: repository.branch.current.fullName)
+        BranchStatus status = repository.branch.status(name: repository.branch.current.fullName)
         return status.aheadCount != 0 || status.behindCount != 0
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -1,7 +1,6 @@
 package pl.allegro.tech.build.axion.release.infrastructure.git
 
 import org.ajoberstar.grgit.Grgit
-import org.ajoberstar.grgit.exception.GrgitException
 import org.eclipse.jgit.lib.Config
 import org.eclipse.jgit.transport.RemoteConfig
 import org.eclipse.jgit.transport.URIish
@@ -72,7 +71,7 @@ class GitRepositoryTest extends Specification {
         repository.tag('release-1')
 
         then:
-        thrown(GrgitException)
+        thrown(Exception)
         rawRepository.tag.list()*.fullName == ['refs/tags/release-1']
     }
 


### PR DESCRIPTION
Updated jgit and grgit to latest versions. Build succeeds and unit tests pass. Of note -
- Latest grgit requires Java 8 (perhaps this is undesirable?)
- GitRepositoryTest used a grgit exception class removed in latest version; replaced with Exception

The issue which prompted this PR
- GitRepository.checkAheadOfRemote() does not have a unit test and failed in real life usage due to an api change in grgit BranchService. I'm not sure if there are other similar issues of this type lurking in the code base.