### PR TITLE
Fixes breaking change in branch name when in detached mode

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -185,10 +185,15 @@ class GitRepository implements ScmRepository {
             shortRevision = revision[0..(7 - 1)]
         }
 
+        // this returns HEAD as branch name when in detached state
+        String branchName = Optional.of(jgitRepository.repository.exactRef(Constants.HEAD)?.target.name)
+            .map({s -> Repository.shortenRefName(s)})
+            .orElse(null)
+
         return new ScmPosition(
             revision,
             shortRevision,
-            jgitRepository.repository.branch
+            branchName
         )
     }
 


### PR DESCRIPTION
resolves #230 

>= 1.9.0: commit id, < 1.9.0: HEAD
changed back to HEAD