### PR TITLE
added regex to filter out tags which overlap in repo

### DIFF
--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
@@ -81,15 +81,15 @@ class SimpleIntegrationTest extends BaseIntegrationTest {
         versionFile.text == "Version: 1.0.0"
     }
 
-    def "should fail gracefuly when failed to parse tag"() {
+    def "should not fail when not exact tag found and return initial version"() {
         given:
         buildFile('')
         repository.tag('release-blabla-1.0.0')
 
         when:
-        def result = gradle().withArguments('cV').buildAndFail()
+        def result = gradle().withArguments('cV').build()
 
         then:
-        result.output.contains('release-blabla')
+        result.output.contains('0.1.0-SNAPSHOT')
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -54,7 +54,7 @@ class VersionResolver {
     private Map readVersions(VersionFactory versionFactory,
                              TagProperties tagProperties,
                              NextVersionProperties nextVersionProperties) {
-        Pattern releaseTagPattern = ~/^${tagProperties.prefix}.*/
+        Pattern releaseTagPattern = ~/^${tagProperties.prefix}${tagProperties.versionSeparator}\d+\.\d+\.\d+.*/
         Pattern nextVersionTagPattern = ~/.*${nextVersionProperties.suffix}$/
 
         Map currentVersionInfo, previousVersionInfo
@@ -81,7 +81,8 @@ class VersionResolver {
     private Map readVersionsByHighestVersion(VersionFactory versionFactory,
                                              TagProperties tagProperties,
                                              NextVersionProperties nextVersionProperties) {
-        Pattern releaseTagPattern = ~/^${tagProperties.prefix}.*/
+
+        Pattern releaseTagPattern = ~/^${tagProperties.prefix}${tagProperties.versionSeparator}\d+\.\d+\.\d+.*/
         Pattern nextVersionTagPattern = ~/.*${nextVersionProperties.suffix}$/
 
         Map currentVersionInfo, previousVersionInfo
@@ -135,7 +136,7 @@ class VersionResolver {
 
         def versionList = versions.asList()
         Collections.sort(versionList, Collections.reverseOrder())
-        
+
         Version version = versionList.find { !isVersionNextVersion[it] } ?: versionList[0] ?: versionFactory.initialVersion()
 
         TagsOnCommit versionCommit = versionToCommit.get(version)

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
@@ -313,4 +313,21 @@ class VersionResolverTest extends RepositoryBasedTest {
       version.snapshot
     }
 
+    def 'should not raise exception when tags has overlapping prefix'() {
+        repository.tag('release-1.0.0')
+        repository.tag('release-1.0.0-rc1')
+        repository.commit(['*'], 'some commit')
+        repository.tag('release-blabla-1.0.0')
+        repository.tag('release-blabla-1.0.5')
+        repository.tag('release-1.10')
+
+        VersionProperties versionProps = versionProperties().build()
+
+        when:
+        VersionContext version = resolver.resolveVersion(versionProps, tagRules, nextVersionRules)
+
+        then:
+        version.version.toString() == '1.0.1'
+        version.snapshot
+    }
 }


### PR DESCRIPTION
This pull request fixes the following restriction: tag prefixes for each module do not overlap, i.e. !tagA.startsWith(tagB) for each permutation of all tag prefixes

Now tags are filtered by stronger regex, filtering out all tags that do not match the pattern <tagPrefix><tagSeparator>-<semver>