### PR TITLE
Fixes Gradle integraiton test setup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'java-gradle-plugin'
     id 'maven'
     id 'jacoco'
-    id 'pl.allegro.tech.build.axion-release' version '1.9.0'
+    id 'pl.allegro.tech.build.axion-release' version '1.9.1'
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'com.gradle.plugin-publish' version '0.9.10'
     id 'com.bmuschko.nexus' version '2.3.1' apply false
@@ -132,6 +132,7 @@ task integrationTest(type: Test) {
 
     testLogging {
         events 'passed', 'skipped', 'failed'
+        showStandardStreams = true
         exceptionFormat = 'full'
     }
 }

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/BaseIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/BaseIntegrationTest.groovy
@@ -19,8 +19,11 @@ class BaseIntegrationTest extends RepositoryBasedTest {
             id 'pl.allegro.tech.build.axion-release'
         }
 
+        """ + contents +
+            """
+
         project.version = scmVersion.version
-        """ + contents
+        """
     }
 
     void vanillaBuildFile(String contents) {
@@ -29,8 +32,8 @@ class BaseIntegrationTest extends RepositoryBasedTest {
 
     GradleRunner gradle() {
         return GradleRunner.create()
-                .withProjectDir(directory)
-                .withPluginClasspath()
+            .withProjectDir(directory)
+            .withPluginClasspath()
     }
 
     BuildResult runGradle(String... arguments) {

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/SimpleIntegrationTest.groovy
@@ -92,4 +92,22 @@ class SimpleIntegrationTest extends BaseIntegrationTest {
         then:
         result.output.contains('release-blabla')
     }
+
+    def "should use initial verison setting"() {
+        given:
+        buildFile("""
+            scmVersion {
+                tag {
+                    initialVersion = { t, p -> '0.0.1' }
+                }
+            }
+        """)
+
+        when:
+        def result = runGradle('cV')
+
+        then:
+        result.output.contains('Project version: 0.0.1-SNAPSHOT')
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
 }


### PR DESCRIPTION
Bug in integration tests setup code caused project.version
to be assigned before adding custom code. This means that
no version reading customizations were active in integraiton tests.