### PR TITLE
fixes using release.customKey property on windows

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/util/FileLoader.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/util/FileLoader.groovy
@@ -24,15 +24,29 @@ final class FileLoader {
         if (file instanceof File) {
             return file
         } else {
-            return new File(adjustStringPath(file.toString()))
+            return fileFromStringPath(file.toString())
         }
     }
 
-    private static String adjustStringPath(String string) {
+    private static File fileFromStringPath(String string) {
+        // fixes using release.customKey property on windows
+        // 'C:/path/to/keyFile.ppk' is not recognized as absolute path
+
+        // WAS:
+        /*
         if (!string.startsWith(File.separator) && root != null) {
             return root.canonicalPath + File.separator + string
         }
         return string
+        */
+        
+        // FIX:
+        File path = new File(string)
+        
+        if (!path.isAbsolute() && root != null) {
+            return new File(root, string)
+        }
+        return path
     }
 
 }


### PR DESCRIPTION
I have found out, that using the -Prelease.customKey=path_to_file does not work on windows when the path is absolute. (E.g. -Prelease.customKey=C:\\ssh\\jenkins_build_ssh_key.ppk)

The axion-release-plugin determines it is relative and appends it to the root path for the project resulting in bad file (e.g. C:\Jenkins\job\1\workspace\C:\ssh\jenkins_build_ssh_key.ppk).

- I have created a patch that fixes this problem and now I am opening a pull request.
- But I have not created any automated test case.
- Building the axion-release-plugin has succeeded locally (regression tests passed)
- I have distributed the plugin to our company repository and used it successfully in Jenkins running on a windows host.

EDIT: I have since found out that if the -Prelease.customKey property is prefixed with the '\\' (== File.separator), it worked even before this fix was applied (E.g. -Prelease.customKey=\\C:\\ssh\\jenkins_build_ssh_key.ppk). So this fix is not strictly necessary. I leave it up to you to merge or reject it.