### PR TITLE
Reintroduce SSH agent support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,9 @@ repositories {
 }
 
 project.ext.versions = [
-        jgit: '4.11.0.201803080745-r'
+        jgit: '4.11.0.201803080745-r',
+        jsch: '0.1.54',
+        jschAgent: '0.0.9'
 ]
 
 sourceSets {
@@ -80,7 +82,14 @@ dependencies {
     compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: versions.jgit
     compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.ui', version: versions.jgit
 
-    compile group: 'com.jcraft', name: 'jsch', version: '0.1.54'
+    compile group: 'com.jcraft', name: 'jsch', version: versions.jsch
+    compile group: 'com.jcraft', name: 'jsch.agentproxy.core', version: versions.jschAgent
+    compile group: 'com.jcraft', name: 'jsch.agentproxy.jsch', version: versions.jschAgent
+    compile group: 'com.jcraft', name: 'jsch.agentproxy.sshagent', version: versions.jschAgent
+    compile group: 'com.jcraft', name: 'jsch.agentproxy.pageant', version: versions.jschAgent
+    compile group: 'com.jcraft', name: 'jsch.agentproxy.usocket-jna', version: versions.jschAgent
+    compile group: 'com.jcraft', name: 'jsch.agentproxy.usocket-nc', version: versions.jschAgent
+
     compile group: 'com.github.zafarkhaja', name: 'java-semver', version: '0.9.0'
 
     testCompile (group: 'org.ajoberstar', name: 'grgit', version: '1.7.2') {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmIdentity.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmIdentity.groovy
@@ -7,20 +7,26 @@ public class ScmIdentity {
 
     final boolean useDefault
 
+    final boolean disableAgentSupport
+
     final boolean privateKeyBased
-    
+
     final boolean usernameBased
-    
+
     final String privateKey
 
     final String passPhrase
-    
+
     final String username
-    
+
     final String password
 
     static ScmIdentity defaultIdentity() {
         return new ScmIdentity(useDefault: true)
+    }
+
+    static ScmIdentity defaultIdentityWithoutAgents() {
+        return new ScmIdentity(useDefault: true, disableAgentSupport: true)
     }
 
     static ScmIdentity keyIdentity(String privateKey, String passPhrase) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmIdentityFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmIdentityFactory.groovy
@@ -6,12 +6,14 @@ import pl.allegro.tech.build.axion.release.util.FileLoader
 
 class ScmIdentityFactory {
 
-    static ScmIdentity create(RepositoryConfig config) {
+    static ScmIdentity create(RepositoryConfig config, boolean disableSshAgent) {
         ScmIdentity identity
         if (config.customKey) {
             identity = ScmIdentity.keyIdentity(FileLoader.readIfFile(config.customKey), config.customKeyPassword)
         } else if (config.customUsername) {
             identity = ScmIdentity.usernameIdentity(config.customUsername, config.customPassword)
+        } else if (disableSshAgent) {
+            identity = ScmIdentity.defaultIdentityWithoutAgents()
         } else {
             identity = ScmIdentity.defaultIdentity()
         }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
@@ -12,6 +12,8 @@ class ScmPropertiesFactory {
 
     private static final String RELEASE_PUSH_TAGS_ONLY_PROPERTY = 'release.pushTagsOnly'
 
+    private static final String DISABLE_SSH_AGENT = 'release.disableSshAgent'
+
     static ScmProperties create(Project project, VersionConfig config) {
         return new ScmProperties(
                 config.repository.type,
@@ -21,7 +23,7 @@ class ScmPropertiesFactory {
                 project.hasProperty(FETCH_TAGS_PROPERTY),
                 project.hasProperty(ATTACH_REMOTE_PROPERTY),
                 (String) (project.hasProperty(ATTACH_REMOTE_PROPERTY) ? project.property(ATTACH_REMOTE_PROPERTY) : null),
-                ScmIdentityFactory.create(config.repository)
+                ScmIdentityFactory.create(config.repository, project.hasProperty(DISABLE_SSH_AGENT))
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -48,7 +48,7 @@ class GitRepository implements ScmRepository {
 
     /**
      * This fetch method behaves like git fetch, meaning it only fetches thing without merging.
-     * As a result, any fetchet tags will not be visible via GitRepository tag listing methods
+     * As a result, any fetched tags will not be visible via GitRepository tag listing methods
      * because they do commit-tree walk, not tag listing.
      *
      * This method is only useful if you have bare repo on CI systems, where merge is not neccessary, because newest

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/SshAgentIdentityRepositoryFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/SshAgentIdentityRepositoryFactory.groovy
@@ -1,0 +1,135 @@
+package pl.allegro.tech.build.axion.release.infrastructure.git
+
+import com.jcraft.jsch.IdentityRepository
+import com.jcraft.jsch.agentproxy.Connector
+import com.jcraft.jsch.agentproxy.RemoteIdentityRepository
+import com.jcraft.jsch.agentproxy.USocketFactory
+import com.jcraft.jsch.agentproxy.connector.PageantConnector
+import com.jcraft.jsch.agentproxy.connector.SSHAgentConnector
+import com.jcraft.jsch.agentproxy.usocket.JNAUSocketFactory
+import com.jcraft.jsch.agentproxy.usocket.NCUSocketFactory
+import pl.allegro.tech.build.axion.release.domain.logging.ReleaseLogger
+
+/**
+ * Content of this class is based on GrGit 2.x agent connector implementation.
+ * TODO: add link to github
+ *
+ * GrGit dropped support for JSch in favor of using native SSH command. However for the limited operations used by
+ * axion-release-plugin, JSch seems to be sufficient.
+ */
+class SshAgentIdentityRepositoryFactory {
+
+    private static final ReleaseLogger logger = ReleaseLogger.Factory.logger(SshAgentIdentityRepositoryFactory)
+
+    static Optional<IdentityRepository> tryToCreateIdentityRepository() {
+        Connector connector
+        IdentityRepository repository = null
+
+        logger.info("Trying to connect any to SSH agent for repository credentials")
+        connector = trySshAgent()
+
+        if (connector == null) {
+            connector = tryPageant()
+        }
+
+        if (connector != null) {
+            repository = createIdentityRepository(connector)
+        }
+
+        if (repository != null) {
+            logger.info("Successfully connected to SSH agent and fetched identities, see debug logs for details")
+        } else {
+            logger.info("Failed to connect to SSH agent, see debug logs for details")
+        }
+
+        return Optional.ofNullable(repository)
+    }
+
+    private static IdentityRepository createIdentityRepository(Connector connector) {
+        IdentityRepository repository = new RemoteIdentityRepository(connector)
+
+        try {
+            if (!repository.getIdentities().isEmpty()) {
+                return repository
+            } else {
+                logger.debug("SSH agent holds no identities, not going to use it")
+                return null
+            }
+        } catch (Throwable e) {
+            logger.warn("Failed to fetch identities from SSH agent, see debug logs for details")
+            logger.debug(stacktrace(e))
+        }
+
+    }
+
+    private static Connector trySshAgent() {
+        Connector connector = null
+        if (SSHAgentConnector.isConnectorAvailable()) {
+            logger.debug("Found ssh-agent, trying to connect")
+
+            Optional<USocketFactory> socketFactory = tryToCreateSocketFactory()
+            if (socketFactory.isPresent()) {
+                logger.debug("Connected to ssh-agent, using it as identity provider")
+                try {
+                    connector = new SSHAgentConnector(socketFactory.get())
+                } catch (Throwable e) {
+                    logger.warn("Failed to use ssh-agent as identity provider, see debug logs for details")
+                    logger.debug(stacktrace(e))
+                }
+            } else {
+                logger.warn("ssh-agent detected, but failed to connect, see debug logs for details")
+            }
+        }
+        return connector
+    }
+
+    private static Connector tryPageant() {
+        Connector connector = null
+        if (PageantConnector.isConnectorAvailable()) {
+            logger.debug("Found pageant, trying to connect")
+            try {
+                connector = new PageantConnector()
+            } catch (Throwable e) {
+                logger.warn("Failed to use pageant as identity provider, see debug logs for details")
+                logger.debug(stacktrace(e))
+            }
+        }
+        return connector
+    }
+
+    private static Optional<USocketFactory> tryToCreateSocketFactory() {
+        USocketFactory factory = null
+        Throwable exception = null
+        try {
+            factory = new JNAUSocketFactory()
+        } catch (Throwable e) {
+            exception = e
+        }
+
+        if (factory == null) {
+            try {
+                factory = new NCUSocketFactory()
+            }
+            catch (Throwable e) {
+                exception = e
+            }
+        }
+
+        if (factory == null) {
+            logger.warn("Failed to connect to ssh-agent, see debug logs for details")
+            logger.debug(stacktrace(exception))
+        }
+
+        return Optional.ofNullable(factory)
+    }
+
+    private static String stacktrace(Throwable e) {
+        StringWriter writer = new StringWriter()
+        try {
+            e.printStackTrace(new PrintWriter(writer))
+            return writer.toString()
+        } finally {
+            writer.close()
+        }
+    }
+}

--- a/src/test-remote/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
+++ b/src/test-remote/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
@@ -27,7 +27,7 @@ class RemoteRejectionTest extends Specification {
             @Override
             void configure(Transport transport) {
                 SshTransport sshTransport = (SshTransport) transport
-                sshTransport.setSshSessionFactory(new SshConnector(ScmIdentity.defaultIdentity()))
+                sshTransport.setSshSessionFactory(new SshConnector(ScmIdentity.defaultIdentityWithoutAgents()))
             }
         })
             .setURI("ssh://git@localhost:${SSH_PORT}/git-server/repos/rejecting-repo")
@@ -40,7 +40,7 @@ class RemoteRejectionTest extends Specification {
         repository.commit(['*'], 'commit after release-custom')
 
         when:
-        ScmPushResult result = repository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions(remote: 'origin', pushTagsOnly: false), true)
+        ScmPushResult result = repository.push(ScmIdentity.defaultIdentityWithoutAgents(), new ScmPushOptions(remote: 'origin', pushTagsOnly: false), true)
 
         then:
         !result.success

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
@@ -23,7 +23,7 @@ class ScmPropertiesBuilder {
                 false,
                 false,
                 null,
-                ScmIdentity.defaultIdentity()
+                ScmIdentity.defaultIdentityWithoutAgents()
         )
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmIdentityFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmIdentityFactoryTest.groovy
@@ -13,10 +13,23 @@ class ScmIdentityFactoryTest extends Specification {
         RepositoryConfig config = new RepositoryConfig()
 
         when:
-        ScmIdentity identity = ScmIdentityFactory.create(config)
+        ScmIdentity identity = ScmIdentityFactory.create(config, false)
 
         then:
         identity.useDefault
+        !identity.disableAgentSupport
+    }
+
+    def "should return no-ssh-agent identity when support for ssh agents disabled"() {
+        given:
+        RepositoryConfig config = new RepositoryConfig()
+
+        when:
+        ScmIdentity identity = ScmIdentityFactory.create(config, true)
+
+        then:
+        identity.useDefault
+        identity.disableAgentSupport
     }
 
     def "should return custom identity when key set"() {
@@ -24,7 +37,7 @@ class ScmIdentityFactoryTest extends Specification {
         RepositoryConfig config = new RepositoryConfig(customKey: 'key', customKeyPassword: 'password')
 
         when:
-        ScmIdentity identity = ScmIdentityFactory.create(config)
+        ScmIdentity identity = ScmIdentityFactory.create(config, false)
 
         then:
         !identity.useDefault
@@ -43,7 +56,7 @@ class ScmIdentityFactoryTest extends Specification {
         RepositoryConfig config = new RepositoryConfig(customKey: keyFile, customKeyPassword: 'password')
 
         when:
-        ScmIdentity identity = ScmIdentityFactory.create(config)
+        ScmIdentity identity = ScmIdentityFactory.create(config, false)
 
         then:
         !identity.useDefault

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
@@ -24,7 +24,7 @@ class DryRepositoryTest extends Specification {
 
     def "should not push anything to scm"() {
         when:
-        dryRepository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions('dry-remote', false))
+        dryRepository.push(ScmIdentity.defaultIdentityWithoutAgents(), new ScmPushOptions('dry-remote', false))
 
         then:
         0 * scm.push(_, _)

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
@@ -20,7 +20,7 @@ class GitProjectBuilder {
 
         this.rawRepository = Grgit.init(dir: repositoryDir)
         this.scmProperties = ScmPropertiesBuilder.scmProperties(repositoryDir).build()
-        this.identity = ScmIdentity.defaultIdentity()
+        this.identity = ScmIdentity.defaultIdentityWithoutAgents()
     }
 
     private GitProjectBuilder(File project, File cloneFrom) {
@@ -28,7 +28,7 @@ class GitProjectBuilder {
 
         this.rawRepository = Grgit.clone(dir: repositoryDir, uri: "file://${cloneFrom.canonicalPath}")
         this.scmProperties = ScmPropertiesBuilder.scmProperties(repositoryDir).build()
-        this.identity = ScmIdentity.defaultIdentity()
+        this.identity = ScmIdentity.defaultIdentityWithoutAgents()
     }
 
     static GitProjectBuilder gitProject(File project) {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -262,7 +262,7 @@ class GitRepositoryTest extends Specification {
         repository.commit(['*'], 'commit after release-push')
 
         when:
-        repository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions(remote: 'origin', pushTagsOnly: false), true)
+        repository.push(ScmIdentity.defaultIdentityWithoutAgents(), new ScmPushOptions(remote: 'origin', pushTagsOnly: false), true)
 
         then:
         remoteRawRepository.log(maxCommits: 1)*.fullMessage == ['commit after release-push']
@@ -274,7 +274,7 @@ class GitRepositoryTest extends Specification {
         repository.commit(['*'], 'commit after release-push')
 
         when:
-        repository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions(remote: 'origin', pushTagsOnly: true))
+        repository.push(ScmIdentity.defaultIdentityWithoutAgents(), new ScmPushOptions(remote: 'origin', pushTagsOnly: true))
 
         then:
         remoteRawRepository.log(maxCommits: 1)*.fullMessage == ['InitialCommit']
@@ -291,7 +291,7 @@ class GitRepositoryTest extends Specification {
         repository.attachRemote('customRemote', "file://$customRemoteProjectDir.canonicalPath")
 
         when:
-        repository.push(ScmIdentity.defaultIdentity(), new ScmPushOptions(remote: 'customRemote', pushTagsOnly: false), true)
+        repository.push(ScmIdentity.defaultIdentityWithoutAgents(), new ScmPushOptions(remote: 'customRemote', pushTagsOnly: false), true)
 
         then:
         customRemoteRawRepository.log(maxCommits: 1)*.fullMessage == ['commit after release-custom']
@@ -311,7 +311,7 @@ class GitRepositoryTest extends Specification {
         remoteRepository.tag("remote-tag-to-fetch")
 
         when:
-        repository.fetchTags(ScmIdentity.defaultIdentity(), 'origin')
+        repository.fetchTags(ScmIdentity.defaultIdentityWithoutAgents(), 'origin')
 
         then:
         rawRepository.tag.list().size() == 1
@@ -338,7 +338,7 @@ class GitRepositoryTest extends Specification {
     def "should fail ahead of remote check when repository behind remote"() {
         given:
         remoteRepository.commit(["*"], "remote commit")
-        repository.fetchTags(ScmIdentity.defaultIdentity(), "origin")
+        repository.fetchTags(ScmIdentity.defaultIdentityWithoutAgents(), "origin")
 
         expect:
         repository.checkAheadOfRemote()


### PR DESCRIPTION
Reintroduces SSH agent support which was gone in `1.9.x` versions due to removal of `GrGit` dependency. Fixes #226 . Will be released as 1.10.