### PR TITLE
fix markNextVersion task documentation

### DIFF
--- a/docs/configuration/next_version.md
+++ b/docs/configuration/next_version.md
@@ -30,7 +30,7 @@ is not incremented:
     # ./gradlew cV
     2.0.1-SNAPSHOT
 
-    # ./gradlew nextVersion –Pincrementer=incrementMinor
+    # ./gradlew marNextVersion -Prelease.incrementer=incrementMinor
 
     # ./gradlew cV
     2.1.0-SNAPSHOT


### PR DESCRIPTION
Change the second to last command of the sample session to correct task and property name.
fixes #276