### PR TITLE
add some debug logging around version resolution

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactory.groovy
@@ -2,12 +2,13 @@ package pl.allegro.tech.build.axion.release.domain
 
 import com.github.zafarkhaja.semver.ParseException
 import com.github.zafarkhaja.semver.Version
-import org.gradle.api.GradleException
+import groovy.util.logging.Slf4j
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 
+@Slf4j
 class VersionFactory {
 
     private final VersionProperties versionProperties
@@ -45,9 +46,14 @@ class VersionFactory {
     }
 
     Map createFinalVersion(ScmState scmState, Version version) {
+
+        log.debug("create final version, scmState: {}, version: {}", scmState, version)
+
         boolean hasUncommittedChanges = !versionProperties.ignoreUncommittedChanges && scmState.hasUncommittedChanges
         boolean hasCommittedChanges = !scmState.onReleaseTag
         boolean hasChanges = hasCommittedChanges || hasUncommittedChanges
+
+        log.debug("hasUncommittedChanges: {}, hasCommittedChanges: {}, hasChanges: {}", hasUncommittedChanges, hasCommittedChanges, hasChanges)
 
         boolean forcesSameVersionAsCurrent = versionProperties.forceVersion() &&
             versionProperties.forcedVersion == version.toString()

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release.domain
 
 import com.github.zafarkhaja.semver.Version
+import groovy.util.logging.Slf4j
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties
@@ -19,6 +20,7 @@ import java.util.regex.Pattern
  *   * version read from last release tag and incremented when not on tag
  *   * version read from last release tag when on tag
  */
+@Slf4j
 class VersionResolver {
 
     private final ScmRepository repository
@@ -77,13 +79,18 @@ class VersionResolver {
 
         Version currentVersion = currentVersionInfo.version
         Version previousVersion = previousVersionInfo.version
-        return [
+
+        Map result = [
             current         : currentVersion,
             previous        : previousVersion,
             onReleaseTag    : currentVersionInfo.isHead && !currentVersionInfo.isNextVersion,
             onNextVersionTag: currentVersionInfo.isNextVersion,
             noTagsFound     : currentVersionInfo.noTagsFound
         ]
+
+        log.debug("read versions: {}", result)
+
+        return result
     }
 
     private Map readVersionsByHighestVersion(VersionFactory versionFactory,

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -303,7 +303,16 @@ class GitRepository implements ScmRepository {
 
     @Override
     boolean checkUncommittedChanges() {
-        return !jgitRepository.status().call().isClean()
+        Status status = jgitRepository.status().call()
+        logger.debug("""git status check:
+            |  added:       ${status.added}
+            |  changed:     ${status.changed}
+            |  removed:     ${status.removed}
+            |  missing:     ${status.missing}
+            |  modified:    ${status.modified}
+            |  conflicting: ${status.conflicting}
+            |  untracked:   ${status.untracked}""".stripMargin())
+        return !status.isClean()
     }
 
     @Override


### PR DESCRIPTION
Added a bit of debug logging around the resolution of versions and git status check. I had to add this to figure out why my currentVersion was being resolved as next SNAPSHOT. I figured it might be useful for others.