### PR TITLE
Support fetching authorization from netrc for HTTP protocol

### DIFF
--- a/docs/configuration/authorization.md
+++ b/docs/configuration/authorization.md
@@ -3,7 +3,8 @@
 ## SSH Agent
 
 If no other options are used and repository requires authorization, `axion-release`
-will try to fetch authorization options from SSH agent (`ssh-agent` on Linux and `pageant` on Windows).
+will try to fetch authorization options from SSH agent (`ssh-agent` on Linux and `pageant` on Windows)
+or netrc for HTTP (`<user-home>/.netrc` on Linux and `<user-home>\_netrc>` on Windows).
 
 All interaction with SSH agent is logged on info and debug levels.
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/TransportConfigFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/TransportConfigFactory.groovy
@@ -1,6 +1,8 @@
 package pl.allegro.tech.build.axion.release.infrastructure.git
 
 import org.eclipse.jgit.api.TransportConfigCallback
+import org.eclipse.jgit.transport.HttpTransport
+import org.eclipse.jgit.transport.NetRCCredentialsProvider
 import org.eclipse.jgit.transport.SshTransport
 import org.eclipse.jgit.transport.Transport
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
@@ -25,6 +27,8 @@ class TransportConfigFactory {
                 if(transport instanceof SshTransport) {
                     SshTransport sshTransport = (SshTransport) transport
                     sshTransport.setSshSessionFactory(new SshConnector(identity))
+                } else if(transport instanceof HttpTransport) {
+                    transport.setCredentialsProvider(new NetRCCredentialsProvider())
                 }
             }
         }


### PR DESCRIPTION
When no authorization option is configured, fetch authorization from
netrc file. Use JGit NetRCCredentialsProvider which will load
authorization from <user-home>/.netrc on Linux and from
<user-home>\_netrc on Windows.

Resolves #296