### PR TITLE
Fix a few typos in documentation

### DIFF
--- a/docs/configuration/next_version.md
+++ b/docs/configuration/next_version.md
@@ -36,7 +36,7 @@ is not incremented:
     2.1.0-SNAPSHOT
 
 To create next version marker use `markNextVersion`. Without parameters next version will be created with default
-version incrementer - incrementMinor, which can be overwritten with release.incrementer` parameter.
+version incrementer - incrementMinor, which can be overwritten with `release.incrementer` parameter.
 Custom next version can be created along with command line option `release.version`.
 
 Default next version marker serializer/deserializer can be customized

--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -21,7 +21,7 @@ Version is kept in repository in form of a tag:
     # git tag
     release-1.0.0 release-1.0.1 release-1.1.0
 
-Only tags which math predefined prefix are taken into a count when
+Only tags which match the predefined prefix are taken into account when
 calculating current version. Prefix can be set using
 `scmVersion.tag.prefix` property:
 


### PR DESCRIPTION
 Corrected a few typos and formatting errors I noticed when reading the docs as a user.