### PR TITLE
Remove prefix restriction.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,7 +190,7 @@ gradlePlugin {
 }
 
 jacoco {
-    toolVersion = '0.8.1'
+    toolVersion = '0.8.2'
 }
 
 jacocoTestReport {

--- a/docs/configuration/basic_usage.md
+++ b/docs/configuration/basic_usage.md
@@ -83,8 +83,6 @@ Sometimes it might be desirable to release each module (or just some
 modules) of multi-module project separately. If so, please make sure
 that:
 
--   tag prefixes for each module do not overlap, i.e.
-    `!tagA.startsWith(tagB)` for each permutation of all tag prefixes
 -   keep in mind, that `scmVersion` must be initialized before
     `scmVersion.version` is accessed
 -   apply plugin on each module that should be released on it\'s own

--- a/docs/configuration/basic_usage.md
+++ b/docs/configuration/basic_usage.md
@@ -85,7 +85,37 @@ that:
 
 -   keep in mind, that `scmVersion` must be initialized before
     `scmVersion.version` is accessed
--   apply plugin on each module that should be released on it\'s own
+-   apply plugin on each module that should be released on its own
+
+The plugin ignores tags based on the prefix and version separator
+(i.e. `<prefix><separator>`).  If there is a prefix configured then
+tags that do not start with the configured `<prefix><separator>` are 
+all ignored. If there is no prefix configured then only tags matching
+the version are used for calculating the version (i.e. the version 
+separator is also ignored).
+
+This allows for using the name of the module with an appropriate version
+separator as a namespace in a multi-module project, as shown in the table
+below:
+
+| Module name | Version separator | Tags will appear as |
+|-------------|-------------------|---------------------|
+| `module`    | `-`               | `module-<maj>.<min>.<patch>` |
+| `moduleV2`    | `-`               | `moduleV2-<maj>.<min>.<patch>` |
+
+For example, within `module`, tags that do not start `module-` will be
+ignored. 
+
+**IMPORTANT:**  
+
+Note that if the version separator appears in the prefix then tag parsing
+will fail. For example, the two prefixes below will not work if the version
+separator is `-`:
+
+```
+my-service
+my-service-client
+```
 
 ## Releasing
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -59,7 +59,7 @@ class VersionResolver {
                              NextVersionProperties nextVersionProperties,
                              VersionProperties versionProperties) {
 
-        Pattern releaseTagPattern = ~/^${tagProperties.prefix}.*/
+        Pattern releaseTagPattern = ~/^${tagProperties.prefix}${tagProperties.prefix != '' ? tagProperties.versionSeparator : ''}.*/
         Pattern nextVersionTagPattern = ~/.*${nextVersionProperties.suffix}$/
         boolean forceSnapshot = versionProperties.forceSnapshot
 
@@ -91,7 +91,7 @@ class VersionResolver {
                                              NextVersionProperties nextVersionProperties,
                                              VersionProperties versionProperties) {
 
-        Pattern releaseTagPattern = ~/^${tagProperties.prefix}.*/
+        Pattern releaseTagPattern = ~/^${tagProperties.prefix}${tagProperties.prefix != '' ? tagProperties.versionSeparator : ''}.*/
         Pattern nextVersionTagPattern = ~/.*${nextVersionProperties.suffix}$/
         boolean forceSnapshot = versionProperties.forceSnapshot
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
@@ -24,7 +24,7 @@ class VersionResolverTest extends RepositoryBasedTest {
     TagProperties prefix1TagProperties = new TagProperties(
         serialize: TagNameSerializer.DEFAULT.serializer,
         deserialize: TagNameSerializer.DEFAULT.deserializer,
-        prefix: 'prefix1',
+        prefix: 'prefix',
         versionSeparator: '-',
         initialVersion: { r, p -> '0.1.0' }
     )
@@ -417,10 +417,10 @@ class VersionResolverTest extends RepositoryBasedTest {
 
     def "should distinguish between prefixes with shared characters"(VersionProperties versionProps, TagProperties tagProps, String v, boolean isSnapshot) {
         given:
-        repository.tag('prefix1-1.0.0')
+        repository.tag('prefix-1.0.0')
         repository.tag('prefix2-1.1.0')
         repository.commit(['*'], 'some commit')
-        repository.tag('prefix1-1.1.0')
+        repository.tag('prefix-1.1.0')
         repository.tag('prefix2-1.2.0')
 
         when:

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
@@ -20,24 +20,6 @@ class VersionResolverTest extends RepositoryBasedTest {
 
     VersionProperties defaultVersionRules = versionProperties().build()
 
-    @Shared
-    TagProperties prefix1TagProperties = new TagProperties(
-        serialize: TagNameSerializer.DEFAULT.serializer,
-        deserialize: TagNameSerializer.DEFAULT.deserializer,
-        prefix: 'prefix',
-        versionSeparator: '-',
-        initialVersion: { r, p -> '0.1.0' }
-    )
-
-    @Shared
-    TagProperties prefix2TagProperties = new TagProperties(
-        serialize: TagNameSerializer.DEFAULT.serializer,
-        deserialize: TagNameSerializer.DEFAULT.deserializer,
-        prefix: 'prefix2',
-        versionSeparator: '-',
-        initialVersion: { r, p -> '0.1.0' }
-    )
-
     def setup() {
         resolver = new VersionResolver(repository)
     }
@@ -415,7 +397,7 @@ class VersionResolverTest extends RepositoryBasedTest {
       ]
     }
 
-    def "should distinguish between prefixes with shared characters"(VersionProperties versionProps, TagProperties tagProps, String v, boolean isSnapshot) {
+    def "should distinguish between prefixes with shared characters"(VersionProperties versionProps, String tagPrefix, String v, boolean isSnapshot) {
         given:
         repository.tag('prefix-1.0.0')
         repository.tag('prefix2-1.1.0')
@@ -424,6 +406,13 @@ class VersionResolverTest extends RepositoryBasedTest {
         repository.tag('prefix2-1.2.0')
 
         when:
+        TagProperties tagProps = new TagProperties(
+            serialize: TagNameSerializer.DEFAULT.serializer,
+            deserialize: TagNameSerializer.DEFAULT.deserializer,
+            prefix: tagPrefix,
+            versionSeparator: '-',
+            initialVersion: { r, p -> '0.1.0' }
+        )
         VersionContext version = resolver.resolveVersion(versionProps, tagProps, nextVersionRules)
 
         then:
@@ -433,8 +422,8 @@ class VersionResolverTest extends RepositoryBasedTest {
 
         where:
 
-        versionProps                | tagProps               | v         | isSnapshot
-        versionProperties().build() | prefix1TagProperties   | '1.1.0'   | false
-        versionProperties().build() | prefix2TagProperties   | '1.2.0'   | false
+        versionProps                | tagPrefix   | v         | isSnapshot
+        versionProperties().build() | 'prefix'    | '1.1.0'   | false
+        versionProperties().build() | 'prefix2'   | '1.2.0'   | false
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
@@ -4,7 +4,6 @@ import pl.allegro.tech.build.axion.release.RepositoryBasedTest
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties
-import spock.lang.Shared
 
 import static pl.allegro.tech.build.axion.release.domain.properties.NextVersionPropertiesBuilder.nextVersionProperties
 import static pl.allegro.tech.build.axion.release.domain.properties.TagPropertiesBuilder.tagProperties


### PR DESCRIPTION
Prefixes were hitherto restricted from not colliding, i.e. prefixes
`pre1` and `pre2` were forbidden.
Bumped jacoco version to allow for compilation using JDK8.