### PR TITLE
Fix #308 - migrate to OpenJDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ script: ./gradlew check
 after_success: ./gradlew jacocoTestReport coveralls
 
 jdk:
-  - oraclejdk8
+  - openjdk8
 
 services:
   - docker


### PR DESCRIPTION
This is an urgent fix to fix all builds breaking on Travis.