### PR TITLE
Monorepo support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ repositories {
 }
 
 project.ext.versions = [
-        jgit: '5.5.1.201910021850-r',
+        jgit: '5.6.0.201912101111-r',
         jsch: '0.1.54',
         jschAgent: '0.0.9'
 ]
@@ -99,7 +99,7 @@ dependencies {
 
     compile group: 'com.github.zafarkhaja', name: 'java-semver', version: '0.9.0'
 
-    testCompile (group: 'org.ajoberstar.grgit', name: 'grgit-core', version: '3.1.1') {
+    testCompile (group: 'org.ajoberstar.grgit', name: 'grgit-core', version: '4.0.1') {
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit.ui'
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,13 @@ if (project.hasProperty('mavenCentral')) {
     apply from: 'gradle/mavenCentral.gradle'
 }
 
+sourceSets {
+    main {
+        java { srcDirs = [] }    // no source dirs for the java compiler
+        groovy { srcDirs = ["src/main/java", "src/main/groovy"] }  // compile   everything in src/ with groovy
+    }
+}
+
 scmVersion {
     tag {
         prefix = 'axion-release'
@@ -36,10 +43,11 @@ sourceCompatibility = '1.7'
 
 repositories {
     mavenCentral()
+    jcenter()
 }
 
 project.ext.versions = [
-        jgit: '4.11.0.201803080745-r',
+        jgit: '5.5.1.201910021850-r',
         jsch: '0.1.54',
         jschAgent: '0.0.9'
 ]
@@ -91,7 +99,7 @@ dependencies {
 
     compile group: 'com.github.zafarkhaja', name: 'java-semver', version: '0.9.0'
 
-    testCompile (group: 'org.ajoberstar', name: 'grgit', version: '1.7.2') {
+    testCompile (group: 'org.ajoberstar.grgit', name: 'grgit-core', version: '3.1.1') {
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit.ui'
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
     }
@@ -190,7 +198,7 @@ gradlePlugin {
 }
 
 jacoco {
-    toolVersion = '0.8.1'
+    toolVersion = '0.8.2'
 }
 
 jacocoTestReport {

--- a/build.gradle
+++ b/build.gradle
@@ -16,13 +16,6 @@ if (project.hasProperty('mavenCentral')) {
     apply from: 'gradle/mavenCentral.gradle'
 }
 
-sourceSets {
-    main {
-        java { srcDirs = [] }    // no source dirs for the java compiler
-        groovy { srcDirs = ["src/main/java", "src/main/groovy"] }  // compile   everything in src/ with groovy
-    }
-}
-
 scmVersion {
     tag {
         prefix = 'axion-release'
@@ -53,6 +46,11 @@ project.ext.versions = [
 ]
 
 sourceSets {
+    main {
+        java { srcDirs = [] }    // no source dirs for the java compiler
+        groovy { srcDirs = ["src/main/java", "src/main/groovy"] }  // compile   everything in src/ with groovy
+    }
+
     integration {
         java.srcDir project.file('src/integration/java')
         groovy.srcDir project.file('src/integration/groovy')

--- a/docs/configuration/basic_usage.md
+++ b/docs/configuration/basic_usage.md
@@ -77,7 +77,7 @@ allprojects {
 }
 ```
 
-### Multi-module with multiple versions
+### Multi-module project with multiple versions
 
 Sometimes it might be desirable to release each module (or just some
 modules) of multi-module project separately. If so, please make sure
@@ -117,14 +117,16 @@ my-service
 my-service-client
 ```
 
-Use the `foldersToExclude` configuration parameter to identify submodules
+Use the `projectDirs` configuration parameter within a `monorepos` block to identify submodules
 that should be excluded from consideration when calculating whether to increment
 the version of the parent project.  Typically, you would do this in the top level
 project, assuming that submodules are named after the directory they appear in:
 
 ```
 scmVersion {
-    foldersToExclude = project.subprojects.collect({p -> p.name})
+    monorepos {
+        projectDirs = project.subprojects.collect({p -> p.name})
+    }
 }
 ```
 

--- a/docs/configuration/basic_usage.md
+++ b/docs/configuration/basic_usage.md
@@ -89,6 +89,26 @@ that:
     `scmVersion.version` is accessed
 -   apply plugin on each module that should be released on it\'s own
 
+Use the `foldersToExclude` configuration parameter to identify submodules
+that should be excluded from consideration when calculating whether to increment
+the version of the parent project.  Typically, you would do this in the top level
+project, assuming that submodules are named after the directory they appear in:
+
+```
+scmVersion {
+    foldersToExclude = project.subprojects.collect({p -> p.name})
+}
+```
+
+Version calculation rules:
+1. Changes to files within a submodule increment that submodule's version only.
+2. Changes to a submodule do not cause a change to the parent project's version if
+the parent is set to ignore that submodule, via `foldersToExclude`.
+3. Changes to files in the parent project but which are not in a submodule identified via 
+`foldersToExclude` will cause the parent project's version to increment but not the 
+versions of any submodules.  If this is desired then consider wiring the `createRelease` or
+`release` tasks of the submodules to be dependencies of the tasks of the same name in the parent. 
+
 ## Releasing
 
 ```

--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -28,6 +28,9 @@ All `axion-release-plugin` configuration options:
         // doc: Version / Sanitization
         sanitizeVersion = true // should created version be sanitized, true by default
 
+        // doc: Basic usage / Basic configuration
+        foldersToExclude = ['submodule1', 'submodule2'] // ignore changes in these subdirs when calculating changes to parent
+
         tag { // doc: Version / Parsing
             prefix = 'tag-prefix' // prefix to be used, 'release' by default
             branchPrefix = [ // set different prefix per branch

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
@@ -1,7 +1,6 @@
 package pl.allegro.tech.build.axion.release
 
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.Ignore
 
 import java.util.stream.Collectors
 
@@ -79,7 +78,6 @@ class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
         }
     }
 
-    @Ignore
     def "plugin can distinguish between submodules versions"() {
         given:
         initialProjectConfiguration()
@@ -110,7 +108,6 @@ class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
 
     }
 
-    @Ignore
     def "change to submodule should not change sibling project version"() {
         given:
         initialProjectConfiguration()
@@ -137,7 +134,6 @@ class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
 
     }
 
-    @Ignore
     def "change to submodule should not change root project version"() {
         given:
         initialProjectConfiguration()

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
@@ -1,0 +1,191 @@
+package pl.allegro.tech.build.axion.release
+
+import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Ignore
+
+import java.util.stream.Collectors
+
+class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
+
+    File getSubmoduleDir(String projectName) {
+        return new File(temporaryFolder.root, projectName)
+    }
+
+    void generateSubmoduleBuildFile(String projectName) {
+        File submoduleDir = getSubmoduleDir(projectName)
+        submoduleDir.mkdirs()
+        File buildFile = new File(submoduleDir, "build.gradle")
+        buildFile << """
+        plugins {
+            id 'pl.allegro.tech.build.axion-release'
+        }
+
+        scmVersion {
+            tag {
+                prefix = '${projectName}'
+            }
+        }
+
+        project.version = scmVersion.version
+        """
+    }
+
+    void generateSettingsFile(File dir, List<String> submodules) {
+        String submodulesIncludeString = submodules.stream().map({ m -> "'${m}'" }).collect(Collectors.joining(','))
+        File settings = new File(dir, "settings.gradle")
+        settings << """
+        include ${submodulesIncludeString}
+
+        """
+    }
+
+    void generateGitIgnoreFile(File dir) {
+        File gitIgnore = new File(dir, ".gitignore")
+        gitIgnore << """\
+        .gradle
+        """.stripIndent()
+    }
+
+    /**
+     * Configure the multi-module project for testing.
+     * We start off with v1.0.0 on the parent project and versions 2.0.0 and 3.0.0 for the 2 child projects.
+     */
+    void initialProjectConfiguration() {
+        List<String> submodules = ["project1", "project2"]
+        buildFile('''
+        scmVersion {
+            foldersToExclude = project.subprojects.collect({p -> p.name})
+        }
+        '''
+        )
+        generateSettingsFile(temporaryFolder.root, submodules)
+        generateGitIgnoreFile(temporaryFolder.root)
+
+        repository.commit(['.'], "initial commit of top level project")
+
+        // create version for main project
+        runGradle(':createRelease', '-Prelease.version=1.0.0', '-Prelease.disableChecks')
+
+        // create submodules
+        int versionCounter = 2
+        for (String module : submodules) {
+            // generate the project files
+            generateSubmoduleBuildFile(module)
+            // add to repo
+            repository.commit(["${module}"], "commit submodule ${module}")
+            // tag release for that project
+            runGradle(":${module}:createRelease", "-Prelease.version=${versionCounter}.0.0", '-Prelease.disableChecks')
+            versionCounter++
+        }
+    }
+
+    @Ignore
+    def "plugin can distinguish between submodules versions"() {
+        given:
+        initialProjectConfiguration()
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+    @Ignore
+    def "change to submodule should not change sibling project version"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project1"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project1"], "commit submodule project1")
+        runGradle(":project1:release", "-Prelease.version=4.0.0", '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':project1:currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+    @Ignore
+    def "change to submodule should not change root project version"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project1"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project1"], "commit submodule project1")
+        runGradle(":project1:release", "-Prelease.version=4.0.0", '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "change to root project should not change child project versions"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(temporaryFolder.root, "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["dummy.txt"], "commit parent project")
+        runGradle(":release", "-Prelease.version=4.0.0", '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+}

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
@@ -53,7 +53,9 @@ class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
         List<String> submodules = ["project1", "project2"]
         buildFile('''
         scmVersion {
-            foldersToExclude = project.subprojects.collect({p -> p.name})
+            monorepos {
+                projectDirs = project.subprojects.collect({p -> p.name})
+            }
         }
         '''
         )

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/MonorepoConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/MonorepoConfig.groovy
@@ -1,0 +1,5 @@
+package pl.allegro.tech.build.axion.release.domain
+
+class MonorepoConfig {
+    public List<String> projectDirs = []
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -49,7 +49,7 @@ class VersionConfig {
 
     HooksConfig hooks = new HooksConfig()
 
-    List<String> foldersToExclude = []
+    MonorepoConfig monorepoConfig = new MonorepoConfig()
 
     private Context context
 
@@ -166,5 +166,9 @@ class VersionConfig {
         if (context == null) {
             this.context = GradleAwareContext.create(project, this)
         }
+    }
+
+    void monorepos(Closure c) {
+        project.configure(monorepoConfig, c)
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -49,6 +49,8 @@ class VersionConfig {
 
     HooksConfig hooks = new HooksConfig()
 
+    List<String> foldersToExclude = []
+
     private Context context
 
     private VersionService.DecoratedVersion resolvedVersion = null

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -44,7 +44,7 @@ class VersionResolver {
     }
 
     VersionContext resolveVersion(VersionProperties versionRules, TagProperties tagProperties, NextVersionProperties nextVersionProperties) {
-        if (projectRootRelativePath != null && !projectRootRelativePath.isEmpty()) {
+        if (projectRootRelativePath != null) {
             latestChangePosition = repository.positionOfLastChangeIn(projectRootRelativePath, foldersToExcludeWhenResolvingLatestRelevantRootProjectCommit);
         } else {
             latestChangePosition = repository.currentPosition();

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -41,7 +41,7 @@ class VersionResolver {
     VersionContext resolveVersion(VersionProperties versionRules, TagProperties tagProperties, NextVersionProperties nextVersionProperties) {
         ScmPosition latestChangePosition
         if (projectRootRelativePath) {
-            latestChangePosition = repository.currentPosition(projectRootRelativePath)
+            latestChangePosition = repository.positionOfLastChangeIn(projectRootRelativePath)
         } else {
             latestChangePosition = repository.currentPosition()
         }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolver.groovy
@@ -6,6 +6,7 @@ import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
+import pl.allegro.tech.build.axion.release.domain.scm.TaggedCommits
 import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
 
 import java.util.regex.Pattern
@@ -78,7 +79,8 @@ class VersionResolver {
 
         Map currentVersionInfo, previousVersionInfo
         TagsOnCommit latestTags = repository.latestTags(releaseTagPattern)
-        currentVersionInfo = versionFromTaggedCommits([latestTags], false, nextVersionTagPattern,
+        TaggedCommits latestTaggedCommit = new TaggedCommits([latestTags], latestChangePosition.revision)
+        currentVersionInfo = versionFromTaggedCommits(latestTaggedCommit, false, nextVersionTagPattern,
             versionFactory, forceSnapshot)
         boolean onCommitWithLatestChange = currentVersionInfo.commit == latestChangePosition.revision
 
@@ -86,7 +88,8 @@ class VersionResolver {
         while (previousTags.hasOnlyMatching(nextVersionTagPattern)) {
             previousTags = repository.latestTags(releaseTagPattern, previousTags.commitId)
         }
-        previousVersionInfo = versionFromTaggedCommits([previousTags], true, nextVersionTagPattern,
+        TaggedCommits previousTaggedCommit = new TaggedCommits([previousTags], latestChangePosition.revision)
+        previousVersionInfo = versionFromTaggedCommits(previousTaggedCommit, true, nextVersionTagPattern,
             versionFactory, forceSnapshot)
 
         Version currentVersion = currentVersionInfo.version
@@ -111,7 +114,7 @@ class VersionResolver {
         boolean forceSnapshot = versionProperties.forceSnapshot
 
         Map currentVersionInfo, previousVersionInfo
-        List<TagsOnCommit> allTaggedCommits = repository.taggedCommits(releaseTagPattern)
+        TaggedCommits allTaggedCommits = new TaggedCommits(repository.taggedCommits(releaseTagPattern), latestChangePosition.revision);
 
         currentVersionInfo = versionFromTaggedCommits(allTaggedCommits, false, nextVersionTagPattern,
             versionFactory, forceSnapshot)
@@ -129,7 +132,7 @@ class VersionResolver {
         ]
     }
 
-    private Map versionFromTaggedCommits(List<TagsOnCommit> taggedCommits,
+    private Map versionFromTaggedCommits(TaggedCommits taggedCommits,
                                          boolean ignoreNextVersionTags,
                                          Pattern nextVersionTagPattern,
                                          VersionFactory versionFactory,

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionSorter.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionSorter.groovy
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release.domain
 
 import com.github.zafarkhaja.semver.Version
+import pl.allegro.tech.build.axion.release.domain.scm.TaggedCommits
 import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
 
 import java.util.regex.Pattern
@@ -20,16 +21,16 @@ import java.util.regex.Pattern
  */
 class VersionSorter {
 
-    Map pickTaggedCommit(List<TagsOnCommit> taggedCommits,
-                                  boolean ignoreNextVersionTags,
-                                  boolean forceSnapshot,
-                                  Pattern nextVersionTagPattern,
-                                  VersionFactory versionFactory) {
+    Map pickTaggedCommit(TaggedCommits taggedCommits,
+                         boolean ignoreNextVersionTags,
+                         boolean forceSnapshot,
+                         Pattern nextVersionTagPattern,
+                         VersionFactory versionFactory) {
         Set<Version> versions = []
         Map<Version, Boolean> isVersionNextVersion = [:]
         Map<Version, TagsOnCommit> versionToCommit = new LinkedHashMap<>()
 
-        for (TagsOnCommit tagsEntry : taggedCommits) {
+        for (TagsOnCommit tagsEntry : taggedCommits.getCommits()) {
             List<String> tags = tagsEntry.tags
 
             // next version should be igored when tag is on head
@@ -37,7 +38,7 @@ class VersionSorter {
             // because when on single commit on head - normal ones have precedence
             // however, we should take into account next version
             // in case of forced snapshot
-            boolean ignoreNextVersionOnHead = tagsEntry.isHead &&
+            boolean ignoreNextVersionOnHead = taggedCommits.isLatestCommit(tagsEntry.commitId) &&
                 !tagsEntry.hasOnlyMatching(nextVersionTagPattern) &&
                 !forceSnapshot
 
@@ -75,8 +76,7 @@ class VersionSorter {
             version      : version,
             isNextVersion: isVersionNextVersion.containsKey(version) && isVersionNextVersion[version],
             noTagsFound  : versions.isEmpty(),
-            commit       : versionCommit?.commitId,
-            isHead       : versionCommit?.isHead
+            commit       : versionCommit?.commitId
         ]
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionSorter.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionSorter.groovy
@@ -7,7 +7,7 @@ import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
 import java.util.regex.Pattern
 
 /**
- * Contains logic of sorting out which version should be used when there are mutliple
+ * Contains logic of sorting out which version should be used when there are multiple
  * versions available.
  *
  * Precedence:
@@ -33,7 +33,7 @@ class VersionSorter {
         for (TagsOnCommit tagsEntry : taggedCommits.getCommits()) {
             List<String> tags = tagsEntry.tags
 
-            // next version should be igored when tag is on head
+            // next version should be ignored when tag is on head
             // and there are other, normal tags on it
             // because when on single commit on head - normal ones have precedence
             // however, we should take into account next version

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.groovy
@@ -17,8 +17,10 @@ class VersionProperties {
     final Closure<Version> versionIncrementer
 
     final boolean sanitizeVersion
-    
+
     final boolean useHighestVersion
+
+    final MonorepoProperties monorepoProperties
 
     boolean forceVersion() {
         return forcedVersion != null

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
@@ -18,6 +18,8 @@ interface ScmRepository {
 
     ScmPosition currentPosition()
 
+    ScmPosition currentPosition(String path)
+
     TagsOnCommit latestTags(Pattern pattern)
 
     TagsOnCommit latestTags(Pattern pattern, String sinceCommit)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
@@ -18,7 +18,7 @@ interface ScmRepository {
 
     ScmPosition currentPosition()
 
-    ScmPosition positionOfLastChangeIn(String path)
+    ScmPosition positionOfLastChangeIn(String path, List<String> excludeSubFolders)
 
     TagsOnCommit latestTags(Pattern pattern)
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.groovy
@@ -18,7 +18,7 @@ interface ScmRepository {
 
     ScmPosition currentPosition()
 
-    ScmPosition currentPosition(String path)
+    ScmPosition positionOfLastChangeIn(String path)
 
     TagsOnCommit latestTags(Pattern pattern)
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/TagsOnCommit.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/TagsOnCommit.groovy
@@ -8,16 +8,13 @@ class TagsOnCommit {
 
     final List<String> tags = new ArrayList<>()
 
-    final boolean isHead
-
-    TagsOnCommit(String commitId, List<String> tags, boolean isHead) {
+    TagsOnCommit(String commitId, List<String> tags) {
         this.commitId = commitId
         this.tags.addAll(tags)
-        this.isHead = isHead
     }
 
     static TagsOnCommit empty() {
-        return new TagsOnCommit(null, [], false)
+        return new TagsOnCommit(null, [])
     }
 
     boolean hasOnlyMatching(Pattern pattern) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -58,6 +58,11 @@ class DryRepository implements ScmRepository {
     }
 
     @Override
+    ScmPosition currentPosition(String path) {
+        return delegateRepository.currentPosition(path)
+    }
+
+    @Override
     TagsOnCommit latestTags(Pattern pattern) {
         TagsOnCommit tags = delegateRepository.latestTags(pattern)
         log("Latest tags: ${tags.tags}")

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -58,7 +58,7 @@ class DryRepository implements ScmRepository {
     }
 
     @Override
-    ScmPosition positionOfLastChangeIn(String path) {
+    ScmPosition positionOfLastChangeIn(String path, List<String> excludeSubFolders) {
         return delegateRepository.positionOfLastChangeIn(path)
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -58,8 +58,8 @@ class DryRepository implements ScmRepository {
     }
 
     @Override
-    ScmPosition currentPosition(String path) {
-        return delegateRepository.currentPosition(path)
+    ScmPosition positionOfLastChangeIn(String path) {
+        return delegateRepository.positionOfLastChangeIn(path)
     }
 
     @Override

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -58,26 +58,26 @@ class DummyRepository implements ScmRepository {
     }
 
     @Override
-    ScmPosition positionOfLastChangeIn(String path) {
+    ScmPosition positionOfLastChangeIn(String path, List<String> excludeSubFolders) {
         return new ScmPosition('', '', 'master')
     }
 
     @Override
     TagsOnCommit latestTags(Pattern pattern) {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
-        return new TagsOnCommit(null, [], false)
+        return new TagsOnCommit(null, [])
     }
 
     @Override
     TagsOnCommit latestTags(Pattern pattern, String sinceCommit) {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
-        return new TagsOnCommit(null, [], false)
+        return new TagsOnCommit(null, [])
     }
 
     @Override
     List<TagsOnCommit> taggedCommits(Pattern pattern) {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
-        return [new TagsOnCommit(null, [], false)]
+        return [new TagsOnCommit(null, [])]
     }
 
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -58,6 +58,11 @@ class DummyRepository implements ScmRepository {
     }
 
     @Override
+    ScmPosition currentPosition(String path) {
+        return new ScmPosition('', '', 'master')
+    }
+
+    @Override
     TagsOnCommit latestTags(Pattern pattern) {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
         return new TagsOnCommit(null, [], false)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -58,7 +58,7 @@ class DummyRepository implements ScmRepository {
     }
 
     @Override
-    ScmPosition currentPosition(String path) {
+    ScmPosition positionOfLastChangeIn(String path) {
         return new ScmPosition('', '', 'master')
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactory.groovy
@@ -3,7 +3,6 @@ package pl.allegro.tech.build.axion.release.infrastructure.config
 import org.gradle.api.Project
 import pl.allegro.tech.build.axion.release.domain.PredefinedVersionCreator
 import pl.allegro.tech.build.axion.release.domain.PredefinedVersionIncrementer
-import pl.allegro.tech.build.axion.release.domain.ProjectVersion
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties
 
@@ -18,7 +17,7 @@ class VersionPropertiesFactory {
     private static final String IGNORE_UNCOMMITTED_CHANGES_PROPERTY = 'release.ignoreUncommittedChanges'
 
     private static final String FORCE_SNAPSHOT_PROPERTY = 'release.forceSnapshot'
-    
+
     private static final String USE_HIGHEST_VERSION_PROPERTY = 'release.useHighestVersion'
 
     private static final String VERSION_INCREMENTER_PROPERTY = 'release.versionIncrementer'
@@ -33,7 +32,7 @@ class VersionPropertiesFactory {
 
         boolean ignoreUncommittedChanges = project.hasProperty(IGNORE_UNCOMMITTED_CHANGES_PROPERTY) ?: config.ignoreUncommittedChanges
         boolean forceSnapshot = project.hasProperty(FORCE_SNAPSHOT_PROPERTY)
-        
+
         boolean useHighestVersion = project.hasProperty(USE_HIGHEST_VERSION_PROPERTY) ?: config.useHighestVersion
 
         return new VersionProperties(
@@ -43,7 +42,8 @@ class VersionPropertiesFactory {
                 versionCreator: findVersionCreator(project, config, currentBranch),
                 versionIncrementer: findVersionIncrementer(project, config, currentBranch),
                 sanitizeVersion: config.sanitizeVersion,
-                useHighestVersion: useHighestVersion
+                useHighestVersion: useHighestVersion,
+                monorepoProperties: MonorepoPropertiesFactory.create(project, config.monorepoConfig, currentBranch)
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
@@ -31,6 +31,16 @@ class Context {
 
         instances[ScmRepository] = scmRepository
         instances[VersionService] = new VersionService(new VersionResolver(scmRepository))
+    }
+
+    public Context(Properties rules, ScmRepository scmRepository, ScmProperties scmProperties, File projectRoot, LocalOnlyResolver localOnlyResolver) {
+        this.rules = rules
+        this.scmRepository = scmRepository
+        this.scmProperties = scmProperties
+        this.localOnlyResolver = localOnlyResolver
+
+        instances[ScmRepository] = scmRepository
+        instances[VersionService] = new VersionService(new VersionResolver(scmRepository, scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString()))
 
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
@@ -33,15 +33,18 @@ class Context {
         instances[VersionService] = new VersionService(new VersionResolver(scmRepository))
     }
 
-    public Context(Properties rules, ScmRepository scmRepository, ScmProperties scmProperties, File projectRoot, LocalOnlyResolver localOnlyResolver) {
+    public Context(Properties rules, ScmRepository scmRepository, ScmProperties scmProperties, File projectRoot, LocalOnlyResolver localOnlyResolver, VersionConfig versionConfig) {
         this.rules = rules
         this.scmRepository = scmRepository
         this.scmProperties = scmProperties
         this.localOnlyResolver = localOnlyResolver
 
         instances[ScmRepository] = scmRepository
-        instances[VersionService] = new VersionService(new VersionResolver(scmRepository, scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString()))
-
+        instances[VersionService] = new VersionService(
+            new VersionResolver(scmRepository,
+                scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString(),
+                versionConfig.foldersToExclude)
+        )
     }
 
     private <T> T get(Class<T> clazz) {
@@ -70,9 +73,9 @@ class Context {
 
     Releaser releaser() {
         return new Releaser(
-                versionService(),
-                scmService(),
-                new ReleaseHooksRunner(versionService(), scmService())
+            versionService(),
+            scmService(),
+            new ReleaseHooksRunner(versionService(), scmService())
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
@@ -23,28 +23,14 @@ class Context {
 
     private final LocalOnlyResolver localOnlyResolver
 
-    public Context(Properties rules, ScmRepository scmRepository, ScmProperties scmProperties, LocalOnlyResolver localOnlyResolver) {
+    public Context(Properties rules, ScmRepository scmRepository, ScmProperties scmProperties, File projectRoot, LocalOnlyResolver localOnlyResolver) {
         this.rules = rules
         this.scmRepository = scmRepository
         this.scmProperties = scmProperties
         this.localOnlyResolver = localOnlyResolver
 
         instances[ScmRepository] = scmRepository
-        instances[VersionService] = new VersionService(new VersionResolver(scmRepository))
-    }
-
-    public Context(Properties rules, ScmRepository scmRepository, ScmProperties scmProperties, File projectRoot, LocalOnlyResolver localOnlyResolver, VersionConfig versionConfig) {
-        this.rules = rules
-        this.scmRepository = scmRepository
-        this.scmProperties = scmProperties
-        this.localOnlyResolver = localOnlyResolver
-
-        instances[ScmRepository] = scmRepository
-        instances[VersionService] = new VersionService(
-            new VersionResolver(scmRepository,
-                scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString(),
-                versionConfig.foldersToExclude)
-        )
+        instances[VersionService] = new VersionService(new VersionResolver(scmRepository, scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString()))
     }
 
     private <T> T get(Class<T> clazz) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
@@ -18,8 +18,9 @@ class GradleAwareContext {
             RulesFactory.create(project, versionConfig, scmRepository.currentPosition()),
             scmRepository,
             scmProperties,
-            project.rootDir,
-            LocalOnlyResolverFactory.create(project, versionConfig)
+            project.projectDir,
+            LocalOnlyResolverFactory.create(project, versionConfig),
+            versionConfig
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
@@ -18,6 +18,7 @@ class GradleAwareContext {
             RulesFactory.create(project, versionConfig, scmRepository.currentPosition()),
             scmRepository,
             scmProperties,
+            project.rootDir,
             LocalOnlyResolverFactory.create(project, versionConfig)
         )
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
@@ -19,8 +19,7 @@ class GradleAwareContext {
             scmRepository,
             scmProperties,
             project.projectDir,
-            LocalOnlyResolverFactory.create(project, versionConfig),
-            versionConfig
+            LocalOnlyResolverFactory.create(project, versionConfig)
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -188,7 +188,6 @@ class GitRepository implements ScmRepository {
             LogCommand logCommand = jgitRepository.log().setMaxCount(1)
             for (String excludedPath : excludeSubFolders) {
                 assertPathFormat(excludedPath)
-                assertPathExists(excludedPath)
                 logCommand.excludePath(excludedPath)
             }
             lastCommit = logCommand.call()[0]

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -177,7 +177,7 @@ class GitRepository implements ScmRepository {
     }
 
     @Override
-    ScmPosition currentPosition(String path) {
+    ScmPosition positionOfLastChangeIn(String path) {
         assertPathFormat(path)
         assertPathExists(path)
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -285,7 +285,7 @@ class GitRepository implements ScmRepository {
         for (currentCommit = walk.next(); currentCommit != null; currentCommit = walk.next()) {
             currentTagsList = allTags[currentCommit.id.name]
             if (currentTagsList) {
-                TagsOnCommit taggedCommit = new TagsOnCommit(currentCommit.id.name(), currentTagsList, Objects.equals(currentCommit.id, headId))
+                TagsOnCommit taggedCommit = new TagsOnCommit(currentCommit.id.name(), currentTagsList)
                 taggedCommits.add(taggedCommit)
                 if (stopOnFirstTag) {
                     break

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/MonorepoProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/MonorepoProperties.java
@@ -1,0 +1,19 @@
+package pl.allegro.tech.build.axion.release.domain.properties;
+
+import groovy.transform.Immutable;
+
+import java.util.Collections;
+import java.util.List;
+
+@Immutable
+public class MonorepoProperties {
+    public final List<String> dirsToExclude;
+
+    public MonorepoProperties() {
+        this.dirsToExclude = Collections.emptyList();
+    }
+
+    public MonorepoProperties(List<String> dirsToExclude) {
+        this.dirsToExclude = Collections.unmodifiableList(dirsToExclude);
+    }
+}

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
@@ -1,0 +1,22 @@
+package pl.allegro.tech.build.axion.release.domain.scm;
+
+import java.util.List;
+
+public class TaggedCommits {
+
+    private List<TagsOnCommit> commits;
+    private String latestCommitRevision;
+
+    public TaggedCommits(List<TagsOnCommit> commits, String latestCommitRevision) {
+        this.commits = commits;
+        this.latestCommitRevision = latestCommitRevision;
+    }
+
+    public List<TagsOnCommit> getCommits() {
+        return commits;
+    }
+
+    public boolean isLatestCommit(String revision) {
+        return latestCommitRevision == null ? false : latestCommitRevision.equals(revision);
+    }
+}

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
@@ -1,15 +1,35 @@
 package pl.allegro.tech.build.axion.release.domain.scm;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.regex.Pattern;
 
 public class TaggedCommits {
 
     private List<TagsOnCommit> commits;
     private String latestCommitRevision;
 
-    public TaggedCommits(List<TagsOnCommit> commits, String latestCommitRevision) {
+    private TaggedCommits(ScmPosition latestTagPosition, List<TagsOnCommit> commits) {
         this.commits = commits;
-        this.latestCommitRevision = latestCommitRevision;
+        this.latestCommitRevision = latestTagPosition.getRevision();
+    }
+
+    public static TaggedCommits fromLatestCommit(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition) {
+        TagsOnCommit latestTags = repository.latestTags(tagPattern);
+        return new TaggedCommits(latestTagPosition, Arrays.asList(latestTags));
+    }
+
+    public static TaggedCommits fromAllCommits(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition) {
+        List<TagsOnCommit> taggedCommits = repository.taggedCommits(tagPattern);
+        return new TaggedCommits(latestTagPosition, taggedCommits);
+    }
+
+    public static TaggedCommits fromLatestCommitBeforeNextVersion(ScmRepository repository, Pattern releaseTagPattern, Pattern nextVersionTagPattern, ScmPosition latestTagPosition) {
+        TagsOnCommit previousTags = repository.latestTags(releaseTagPattern);
+        while (previousTags.hasOnlyMatching(nextVersionTagPattern)) {
+            previousTags = repository.latestTags(releaseTagPattern, previousTags.getCommitId());
+        }
+        return new TaggedCommits(latestTagPosition, Arrays.asList(previousTags));
     }
 
     public List<TagsOnCommit> getCommits() {

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
@@ -14,6 +14,10 @@ public class TaggedCommits {
         this.latestCommitRevision = latestTagPosition.getRevision();
     }
 
+    public static TaggedCommits fromListOfCommits(ScmPosition latestTagPosition, List<TagsOnCommit> taggedCommits) {
+        return new TaggedCommits(latestTagPosition, taggedCommits);
+    }
+
     public static TaggedCommits fromLatestCommit(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition) {
         TagsOnCommit latestTags = repository.latestTags(tagPattern);
         return new TaggedCommits(latestTagPosition, Arrays.asList(latestTags));

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/config/MonorepoPropertiesFactory.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/config/MonorepoPropertiesFactory.java
@@ -1,0 +1,11 @@
+package pl.allegro.tech.build.axion.release.infrastructure.config;
+
+import org.gradle.api.Project;
+import pl.allegro.tech.build.axion.release.domain.MonorepoConfig;
+import pl.allegro.tech.build.axion.release.domain.properties.MonorepoProperties;
+
+public class MonorepoPropertiesFactory {
+    public static MonorepoProperties create(Project project, MonorepoConfig config, String currentBranch) {
+        return new MonorepoProperties(config.projectDirs);
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/RepositoryBasedTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/RepositoryBasedTest.groovy
@@ -35,6 +35,7 @@ class RepositoryBasedTest extends Specification {
                 PropertiesBuilder.properties().build(),
                 scmRepository,
                 scmProperties,
+                directory,
                 new LocalOnlyResolver(true)
         )
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/RepositoryBasedTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/RepositoryBasedTest.groovy
@@ -4,7 +4,6 @@ import org.ajoberstar.grgit.Grgit
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import pl.allegro.tech.build.axion.release.domain.LocalOnlyResolver
-import pl.allegro.tech.build.axion.release.domain.properties.Properties
 import pl.allegro.tech.build.axion.release.domain.properties.PropertiesBuilder
 import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverSubfolderTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverSubfolderTest.groovy
@@ -1,0 +1,198 @@
+package pl.allegro.tech.build.axion.release.domain
+
+
+import pl.allegro.tech.build.axion.release.RepositoryBasedTest
+import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties
+import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
+import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties
+
+import static pl.allegro.tech.build.axion.release.domain.properties.NextVersionPropertiesBuilder.nextVersionProperties
+import static pl.allegro.tech.build.axion.release.domain.properties.TagPropertiesBuilder.tagProperties
+import static pl.allegro.tech.build.axion.release.domain.properties.VersionPropertiesBuilder.versionProperties
+
+class VersionResolverSubfolderTest extends RepositoryBasedTest {
+
+    VersionResolver resolver
+
+    TagProperties tagRules = tagProperties().build()
+
+    NextVersionProperties nextVersionRules = nextVersionProperties().build()
+
+    VersionProperties defaultVersionRules = versionProperties().build()
+
+    String projectRootSubfolder
+
+    def setup() {
+        this.projectRootSubfolder = "gradleProjectRoot"
+        resolver = new VersionResolver(repository, projectRootSubfolder)
+    }
+
+    def "should return default previous and current version when no tag in repository"() {
+        given:
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+
+        when:
+        VersionContext version = resolver.resolveVersion(defaultVersionRules, tagRules, nextVersionRules)
+
+        then:
+        version.previousVersion.toString() == '0.1.0'
+        version.version.toString() == '0.1.0'
+        version.snapshot
+
+    }
+
+    def "should return same previous and current version when no change in subfolder since release tag"() {
+        given:
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+        repository.tag('release-1.1.0')
+        repository.commit(['*'], 'Commit without change in subfolder')
+
+        when:
+        VersionContext version = resolver.resolveVersion(defaultVersionRules, tagRules, nextVersionRules)
+
+        then:
+        version.previousVersion.toString() == '1.1.0'
+        version.version.toString() == '1.1.0'
+        !version.snapshot
+    }
+
+    def "should pick tag with highest version when multiple tags on last commit with changes in subfolder"() {
+        given:
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+        repository.tag('release-1.0.0')
+        repository.tag('release-1.1.0')
+        repository.tag('release-1.2.0')
+        repository.commit(['*'], 'Commit without change in subfolder')
+
+        when:
+        VersionContext version = resolver.resolveVersion(defaultVersionRules, tagRules, nextVersionRules)
+
+        then:
+        version.previousVersion.toString() == '1.2.0'
+        version.version.toString() == '1.2.0'
+        !version.snapshot
+    }
+
+    def "should pick tag with highest version when multiple release and non-release tags on last commit with changes in subfolder"() {
+        given:
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+        repository.tag('release-1.0.0')
+        repository.tag('release-1.1.0')
+        repository.tag('release-1.1.5-alpha')
+        repository.tag('release-1.2.0')
+        repository.tag('release-1.4.0-alpha')
+        repository.commit(['*'], 'Commit without change in subfolder')
+
+        when:
+        VersionContext version = resolver.resolveVersion(defaultVersionRules, tagRules, nextVersionRules)
+
+        then:
+        version.previousVersion.toString() == '1.2.0'
+        version.version.toString() == '1.2.0'
+        !version.snapshot
+    }
+
+    def "should prefer snapshot of nextVersion when both on latest relevant commit and forceSnapshot is enabled"() {
+
+        given: "there is releaseTag and nextVersionTag on current commit"
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+        repository.tag('release-1.0.0')
+        repository.tag('release-1.1.0-alpha')
+        repository.commit(['*'], 'Commit without change in subfolder')
+        VersionProperties versionRules = versionProperties().forceSnapshot().build()
+
+        when: "resolving version with property 'release.forceSnapshot'"
+        VersionContext version = resolver.resolveVersion(versionRules, tagRules, nextVersionRules)
+
+        then: "the resolved version should be snapshot towards the next version"
+        version.previousVersion.toString() == '1.0.0'
+        version.version.toString() == '1.1.0'
+        version.snapshot
+    }
+
+    def "should return unmodified previous and incremented current version when changes in subfolder since tag"(VersionProperties versionRules) {
+        given:
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+        repository.tag('release-1.1.0')
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'bar')
+
+        when:
+        VersionContext version = resolver.resolveVersion(versionRules, tagRules, nextVersionRules)
+
+        then:
+        version.previousVersion.toString() == '1.1.0'
+        version.version.toString() == '1.1.1'
+        version.snapshot
+
+        where:
+        versionRules << [
+            versionProperties().build(),
+            versionProperties().forceSnapshot().build()
+        ]
+    }
+
+    def "should return the highest version from the tagged versions, even if subfolder not changed in that commit"(VersionProperties versionProps) {
+        given:
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+        repository.tag('release-1.0.0')
+        repository.commit(['*'], 'Commit without change in subfolder')
+        repository.tag('release-1.5.0')
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'bar')
+        repository.tag('release-1.2.0')
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'bar2')
+        repository.tag('release-1.3.0')
+
+        when:
+        VersionContext version = resolver.resolveVersion(versionProps, tagRules, nextVersionRules)
+        println "Version Resolved: $version"
+
+        then:
+        version.previousVersion.toString() == '1.5.0'
+        version.version.toString() == '1.5.1'
+        version.snapshot
+
+        where:
+        versionProps << [
+            versionProperties().useHighestVersion().build(),
+            versionProperties().useHighestVersion().forceSnapshot().build()
+        ]
+    }
+
+    def "should return the highest version from the tagged versions, even if subfolder not changed in that commit, when not on release"(VersionProperties versionProps) {
+        given:
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'foo')
+        repository.tag('release-1.0.0')
+        repository.commit(['*'], 'Commit without change in subfolder')
+        repository.tag('release-1.5.0')
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'bar')
+        repository.tag('release-1.2.0')
+        createAndCommitFileInSubfolder(projectRootSubfolder, 'bar2')
+        repository.tag('release-1.3.0')
+        repository.commit(['*'], 'Commit without change in subfolder')
+
+        when:
+        VersionContext version = resolver.resolveVersion(versionProps, tagRules, nextVersionRules)
+        println "Version Resolved: $version"
+
+        then:
+        version.previousVersion.toString() == '1.5.0'
+        version.version.toString() == '1.5.1'
+        version.snapshot
+
+        where:
+        versionProps << [
+            versionProperties().useHighestVersion().build(),
+            versionProperties().useHighestVersion().forceSnapshot().build()
+        ]
+    }
+
+    // TODO add missing test cases (see VersionResolverTest as a reference for potential test cases)
+
+    private void createAndCommitFileInSubfolder(String path, String filename) {
+        def subfolder = new File(directory, path)
+        def dummyFile = new File(directory, "${path}/${filename}")
+        subfolder.mkdirs()
+        dummyFile.createNewFile()
+        repository.commit(['.'], "create file ${path}/${filename}")
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
@@ -20,7 +20,7 @@ class VersionResolverTest extends RepositoryBasedTest {
     VersionProperties defaultVersionRules = versionProperties().build()
 
     def setup() {
-        resolver = new VersionResolver(repository)
+        resolver = new VersionResolver(repository, "")
     }
 
     def "should return default previous and current version when no tag in repository"() {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionSorterTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionSorterTest.groovy
@@ -3,7 +3,9 @@ package pl.allegro.tech.build.axion.release.domain
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionPropertiesBuilder
 import pl.allegro.tech.build.axion.release.domain.properties.TagPropertiesBuilder
 import pl.allegro.tech.build.axion.release.domain.properties.VersionPropertiesBuilder
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPositionBuilder
+import pl.allegro.tech.build.axion.release.domain.scm.TaggedCommits
 import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
 import spock.lang.Specification
 
@@ -29,7 +31,8 @@ class VersionSorterTest extends Specification {
     def "should return highest version of all when not on head"() {
         when:
         def versionData = sorter.pickTaggedCommit(
-            [new TagsOnCommit('a', ['release-1.0.0'], false), new TagsOnCommit('b', ['release-2.0.0'], false)],
+            TaggedCommits.fromListOfCommits(new ScmPosition("b", "b", "master"),
+                [new TagsOnCommit('a', ['release-1.0.0']), new TagsOnCommit('b', ['release-2.0.0'])]),
             false,
             false,
             ~/.*-alpha$/,
@@ -43,7 +46,8 @@ class VersionSorterTest extends Specification {
     def "should return highest version of all when not on head and versions on single commit"() {
         when:
         def versionData = sorter.pickTaggedCommit(
-            [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0'], false)],
+            TaggedCommits.fromListOfCommits(new ScmPosition("a", "a", "master"),
+                [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0'])]),
             false,
             false,
             ~/.*-alpha$/,
@@ -58,7 +62,8 @@ class VersionSorterTest extends Specification {
     def "should return highest version of all when alpha is on head"() {
         when:
         def versionData = sorter.pickTaggedCommit(
-            [new TagsOnCommit('a', ['release-1.0.0'], false), new TagsOnCommit('b', ['release-2.0.0-alpha'], true)],
+            TaggedCommits.fromListOfCommits(new ScmPosition("b", "b", "master"),
+                [new TagsOnCommit('a', ['release-1.0.0']), new TagsOnCommit('b', ['release-2.0.0-alpha'])]),
             false,
             false,
             ~/.*-alpha$/,
@@ -72,7 +77,8 @@ class VersionSorterTest extends Specification {
     def "should prefer normal version to alpha version when on head and versions on single commit"() {
         when:
         def versionData = sorter.pickTaggedCommit(
-            [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0-alpha'], true)],
+            TaggedCommits.fromListOfCommits(new ScmPosition("a", "a", "master"),
+                [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0-alpha'])]),
             false,
             false,
             ~/.*-alpha$/,
@@ -86,7 +92,8 @@ class VersionSorterTest extends Specification {
     def "should prefer alpha version to normal version when on head, versions on single commit and snapshot is forced"() {
         when:
         def versionData = sorter.pickTaggedCommit(
-            [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0-alpha'], true)],
+            TaggedCommits.fromListOfCommits(new ScmPosition("a", "a", "master"),
+                [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0-alpha'])]),
             false,
             true,
             ~/.*-alpha$/,
@@ -100,7 +107,8 @@ class VersionSorterTest extends Specification {
     def "should ignore any nextVersion commits when asked"() {
         when:
         def versionData = sorter.pickTaggedCommit(
-            [new TagsOnCommit('a', ['release-1.0.0'], false), new TagsOnCommit('a', ['release-2.0.0-alpha'], false)],
+            TaggedCommits.fromListOfCommits(new ScmPosition("a", "a", "master"),
+                [new TagsOnCommit('a', ['release-1.0.0']), new TagsOnCommit('a', ['release-2.0.0-alpha'])]),
             true,
             false,
             ~/.*-alpha$/,
@@ -114,7 +122,8 @@ class VersionSorterTest extends Specification {
     def "should ignore any nextVersion commits when asked and versions on single commit"() {
         when:
         def versionData = sorter.pickTaggedCommit(
-            [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0-alpha'], false)],
+            TaggedCommits.fromListOfCommits(new ScmPosition("a", "a", "master"),
+                [new TagsOnCommit('a', ['release-1.0.0', 'release-2.0.0-alpha'])]),
             true,
             false,
             ~/.*-alpha$/,

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/MonorepoPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/MonorepoPropertiesBuilder.groovy
@@ -1,0 +1,22 @@
+package pl.allegro.tech.build.axion.release.domain.properties
+
+class MonorepoPropertiesBuilder {
+
+    private List<String> dirsToExclude = []
+
+    private MonorepoPropertiesBuilder() {
+    }
+
+    static MonorepoPropertiesBuilder monorepoProperties() {
+        return new MonorepoPropertiesBuilder()
+    }
+
+    MonorepoProperties build() {
+        return new MonorepoProperties(dirsToExclude)
+    }
+
+    MonorepoPropertiesBuilder excludeDirs(List<String> dirsToExclude) {
+        this.dirsToExclude = dirsToExclude
+        return this
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionPropertiesBuilder.groovy
@@ -13,6 +13,8 @@ class VersionPropertiesBuilder {
 
     private boolean useHighestVersion = false
 
+    private MonorepoProperties monorepoProperties = new MonorepoProperties()
+
     private VersionPropertiesBuilder() {
     }
 
@@ -28,7 +30,8 @@ class VersionPropertiesBuilder {
                 versionCreator: PredefinedVersionCreator.SIMPLE.versionCreator,
                 versionIncrementer: PredefinedVersionIncrementer.versionIncrementerFor('incrementPatch'),
                 sanitizeVersion: true,
-                useHighestVersion: useHighestVersion)
+                useHighestVersion: useHighestVersion,
+                monorepoProperties: monorepoProperties)
     }
 
     VersionPropertiesBuilder forceVersion(String version) {
@@ -48,6 +51,11 @@ class VersionPropertiesBuilder {
 
     VersionPropertiesBuilder useHighestVersion() {
       this.useHighestVersion = true
+      return this
+    }
+
+    VersionPropertiesBuilder supportMonorepos(MonorepoProperties monorepoProperties) {
+      this.monorepoProperties = monorepoProperties
       return this
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/MonorepoPropertiesFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/MonorepoPropertiesFactoryTest.groovy
@@ -1,0 +1,33 @@
+package pl.allegro.tech.build.axion.release.infrastructure.config
+
+import org.gradle.api.Project
+import pl.allegro.tech.build.axion.release.domain.MonorepoConfig
+import pl.allegro.tech.build.axion.release.domain.properties.MonorepoProperties
+import spock.lang.Specification
+
+import static org.gradle.testfixtures.ProjectBuilder.builder
+
+class MonorepoPropertiesFactoryTest extends Specification {
+
+    private Project project
+
+    private MonorepoConfig monorepoConfig
+
+    def setup() {
+        project = builder().build()
+        monorepoConfig = new MonorepoConfig()
+    }
+
+    def "should copy properties from MonorepoConfig object"() {
+        given:
+        monorepoConfig.projectDirs = ["foo", "bar"]
+
+        when:
+        MonorepoProperties rules = MonorepoPropertiesFactory.create(project, monorepoConfig, 'master')
+
+        then:
+        rules.dirsToExclude.size() == 2
+        rules.dirsToExclude.contains("foo")
+        rules.dirsToExclude.contains("bar")
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
@@ -1,7 +1,6 @@
 package pl.allegro.tech.build.axion.release.infrastructure.git
 
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
@@ -40,7 +39,7 @@ class DryRepositoryTest extends Specification {
 
     def "should return latest tags from real scm"() {
         given:
-        TagsOnCommit expected = new TagsOnCommit('commit-id', [], false)
+        TagsOnCommit expected = new TagsOnCommit('commit-id', [])
         scm.latestTags(_) >> expected
 
         when:

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -1,10 +1,6 @@
 package pl.allegro.tech.build.axion.release.infrastructure.git
 
-import org.ajoberstar.grgit.Branch
 import org.ajoberstar.grgit.Grgit
-import org.ajoberstar.grgit.exception.GrgitException
-import org.eclipse.jgit.api.Git
-import org.eclipse.jgit.api.TagCommand
 import org.eclipse.jgit.api.errors.RefAlreadyExistsException
 import org.eclipse.jgit.lib.Config
 import org.eclipse.jgit.lib.Constants

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -113,7 +113,6 @@ class GitRepositoryTest extends Specification {
 
         then:
         tags.tags == ['release-1']
-        !tags.isHead
     }
 
     def "should return no tags when no commit in repository"() {
@@ -125,7 +124,6 @@ class GitRepositoryTest extends Specification {
 
         then:
         tags.tags == []
-        !tags.isHead
     }
 
     def "should indicate that position is on tag when latest commit is tagged"() {
@@ -137,7 +135,6 @@ class GitRepositoryTest extends Specification {
 
         then:
         tags.tags == ['release-1']
-        tags.isHead
     }
 
     def "should track back to older tag when commit was made after checking out older version"() {


### PR DESCRIPTION
This is a reworked version of the initial work done in #291 by @sradi and his PR #292.  To be properly useful, this should make use of the changes in PR #307.

Note that we want to enable the user to exclude changes in submodules from being considered when calculating the version of the parent project.  When determining whether a commit takes place in a submodule, we use JGit's `addPath` command to only look at commits in a particular subdirectory.  However, JGit does not (yet) support excluding directories from its [LogCommand](https://download.eclipse.org/jgit/site/5.5.1.201910021850-r/apidocs/org/eclipse/jgit/api/LogCommand.html).  This is discussed in a StackOverflow question I asked [here](https://stackoverflow.com/questions/59143934/java-jgit-how-to-get-git-commits-not-affecting-certain-directories).

I have created a PR to JGit (https://git.eclipse.org/r/#/c/153673/) where I add a `excludePath()` method to `LogCommand`, which will allow us to exclude directories from consideration when determining whether to increment a project's version.  When this PR is merged and there is a new version released, we should be able to bump the JGit version and the code [in this section](https://github.com/john-tipper/axion-release-plugin/blob/monorepo-support/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy#L187-L195) should work (subject to the ignored tests in [MultiModuleProjectIntegrationTest](https://github.com/john-tipper/axion-release-plugin/blob/monorepo-support/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy)).  Adding the new version of JGit will require the bump to `grgit-core` to support Jgit v5 that you see in `build.gradle`.