### PR TITLE
Introducing `overriddenBranchName` flag

### DIFF
--- a/docs/configuration/ci_servers.md
+++ b/docs/configuration/ci_servers.md
@@ -65,7 +65,29 @@ commit is ahead of remote.
 
 ## Bitbucket Pipelines
 
-Bitbucket Pipelines allow to commit to repository without any configuration. 
+Bitbucket Pipelines allow to commit to repository without any configuration.
 However it requires git client to use local proxy. It can be configured by passing following parameters:
 
     ./gradlew release -Dhttp.proxyHost=localhost -Dhttp.proxyPort=29418
+
+## Azure DevOps Pipelines
+
+Azure Pipelines will check out git repositories in a `detached head` state.
+That is why two flags should be set when running the release task:
+
+    ./gradlew release -Prelease.disableChecks -Prelease.pushTagsOnly
+
+Disabling checks is necessary because `axion-release` is not able to
+verify if current commit is ahead of remote. Setting pushTagsOnly
+ensures that git will not throw an error by attempting to push commits
+while not working on a branch.
+
+To use features related to branches (like [versionWithBranch](version.md#versionwithbranch),
+[branchVersionIncrementer](version.md#incrementing) or [branchVersionCreator](version.md#decorating))
+you need to override branch name with `overriddenBranchName` flag and set it to
+`Build.SourceBranch` Azure Pipelines predefined variable:
+
+    ./gradlew release \
+        -Prelease.disableChecks \
+        -Prelease.pushTagsOnly \
+        -Prelease.overriddenBranchName=$(Build.SourceBranch)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmProperties.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmProperties.groovy
@@ -18,9 +18,11 @@ class ScmProperties {
 
     final ScmIdentity identity
 
+    final String overriddenBranchName
+
     ScmProperties(String type, File directory, String remote, boolean pushTagsOnly,
                   boolean fetchTags, boolean attachRemote, String remoteUrl,
-                  ScmIdentity identity) {
+                  String overriddenBranchName, ScmIdentity identity) {
         this.type = type
         this.directory = directory
         this.remote = remote
@@ -28,6 +30,7 @@ class ScmProperties {
         this.fetchTags = fetchTags
         this.attachRemote = attachRemote
         this.remoteUrl = remoteUrl
+        this.overriddenBranchName = overriddenBranchName
         this.identity = identity
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
@@ -14,6 +14,8 @@ class ScmPropertiesFactory {
 
     private static final String DISABLE_SSH_AGENT = 'release.disableSshAgent'
 
+    private static final String OVERRIDDEN_BRANCH_NAME = 'release.overriddenBranchName'
+
     static ScmProperties create(Project project, VersionConfig config) {
         return new ScmProperties(
                 config.repository.type,
@@ -23,6 +25,7 @@ class ScmPropertiesFactory {
                 project.hasProperty(FETCH_TAGS_PROPERTY),
                 project.hasProperty(ATTACH_REMOTE_PROPERTY),
                 (String) (project.hasProperty(ATTACH_REMOTE_PROPERTY) ? project.property(ATTACH_REMOTE_PROPERTY) : null),
+                (String) (project.hasProperty(OVERRIDDEN_BRANCH_NAME) ? project.property(OVERRIDDEN_BRANCH_NAME) : null),
                 ScmIdentityFactory.create(config.repository, project.hasProperty(DISABLE_SSH_AGENT))
         )
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.groovy
@@ -185,16 +185,22 @@ class GitRepository implements ScmRepository {
             shortRevision = revision[0..(7 - 1)]
         }
 
-        // this returns HEAD as branch name when in detached state
-        String branchName = Optional.of(jgitRepository.repository.exactRef(Constants.HEAD)?.target.name)
-            .map({s -> Repository.shortenRefName(s)})
-            .orElse(null)
-
         return new ScmPosition(
             revision,
             shortRevision,
-            branchName
+            branchName()
         )
+    }
+
+    /**
+     * @return branch name or 'HEAD' when in detached state, unless it is overridden by 'overriddenBranchName'
+     */
+    private String branchName() {
+        String currentBranch = Repository.shortenRefName(jgitRepository.repository.exactRef(Constants.HEAD)?.target.name)
+        if (currentBranch == 'HEAD' && properties.overriddenBranchName != null) {
+            return Repository.shortenRefName(properties.overriddenBranchName)
+        }
+        return currentBranch
     }
 
     @Override

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
@@ -5,6 +5,7 @@ class ScmPropertiesBuilder {
     private final File directory
 
     private String type = 'git'
+    private String overriddenBranchName
 
     private ScmPropertiesBuilder(File directory) {
         this.directory = directory
@@ -12,6 +13,11 @@ class ScmPropertiesBuilder {
 
     static ScmPropertiesBuilder scmProperties(File directory) {
         return new ScmPropertiesBuilder(directory)
+    }
+
+    ScmPropertiesBuilder withOverriddenBranchName(String overriddenBranchName) {
+        this.overriddenBranchName = overriddenBranchName
+        return this
     }
 
     ScmProperties build() {
@@ -23,6 +29,7 @@ class ScmPropertiesBuilder {
                 false,
                 false,
                 null,
+                overriddenBranchName,
                 ScmIdentity.defaultIdentityWithoutAgents()
         )
     }


### PR DESCRIPTION
To be able to use branch-related features when CI is using detached head state of Git repository
This is done to solve issue #311.