### PR TITLE
Convert file separators for JGit LogCommand

### DIFF
--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -224,8 +224,9 @@ public class GitRepository implements ScmRepository {
                 }
                 lastCommit = logCommand.call().iterator().next();
             } else {
-                assertPathExists(path);
-                lastCommit = jgitRepository.log().setMaxCount(1).addPath(path).call().iterator().next();
+                String unixStylePath = path.replaceAll("\\\\", "/");
+                assertPathExists(unixStylePath);
+                lastCommit = jgitRepository.log().setMaxCount(1).addPath(unixStylePath).call().iterator().next();
             }
         } catch (GitAPIException e) {
             throw new ScmException(e);

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -220,11 +220,11 @@ public class GitRepository implements ScmRepository {
             if (path.isEmpty()) {
                 LogCommand logCommand = jgitRepository.log().setMaxCount(1);
                 for (String excludedPath : excludeSubFolders) {
-                    logCommand.excludePath(excludedPath);
+                    logCommand.excludePath(asUnixPath(excludedPath));
                 }
                 lastCommit = logCommand.call().iterator().next();
             } else {
-                String unixStylePath = path.replaceAll("\\\\", "/");
+                String unixStylePath = asUnixPath(path);
                 assertPathExists(unixStylePath);
                 lastCommit = jgitRepository.log().setMaxCount(1).addPath(unixStylePath).call().iterator().next();
             }
@@ -247,6 +247,10 @@ public class GitRepository implements ScmRepository {
                 currentPosition.getBranch()
             );
         }
+    }
+
+    private String asUnixPath(String path) {
+        return path == null ? null : path.replaceAll("\\\\", "/");
     }
 
     private void assertPathExists(String path) {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -405,4 +405,26 @@ class GitRepositoryTest extends Specification {
         then:
         thrown(ScmException)
     }
+
+    def "last position with changes in subdir should work with backslashes"() {
+        given:
+        String subdirA = 'a/aa'
+        String fileInA = "${subdirA}/foo"
+        new File(repositoryDir, subdirA).mkdirs()
+        new File(repositoryDir, fileInA).createNewFile()
+        repository.commit([fileInA], 'Add file foo in subdirA')
+        String headSubDirAChanged = rawRepository.head().id
+
+        String subdirB = 'b/ba'
+        String fileInB = "${subdirB}/bar"
+        new File(repositoryDir, subdirB).mkdirs()
+        new File(repositoryDir, fileInB).createNewFile()
+        repository.commit([fileInB], 'Add file bar in subdirB')
+
+        when:
+        ScmPosition position = repository.positionOfLastChangeIn('a\\aa', [])
+
+        then:
+        position.revision == headSubDirAChanged
+    }
 }


### PR DESCRIPTION
Fixes #322 

The addPath() method of JGit LogCommand only supports '/' as file separator. See http://download.eclipse.org/jgit/site/5.6.0.201912101111-r/apidocs/index.html

I simply convert backslashes to slashes, right before passing the path to LogCommand.
The added test, proves, that this works.