### PR TITLE
#325 #314 Enable multi-module project lib dependency incrementing.

### DIFF
--- a/docs/configuration/basic_usage.md
+++ b/docs/configuration/basic_usage.md
@@ -83,7 +83,7 @@ Sometimes it might be desirable to release each module (or just some
 modules) of multi-module project separately. If so, please make sure
 that:
 
--   keep in mind, that `scmVersion` must be initialized before
+-   you keep in mind that `scmVersion` must be initialized before
     `scmVersion.version` is accessed
 -   apply plugin on each module that should be released on its own
 
@@ -105,6 +105,16 @@ below:
 
 For example, within `module`, tags that do not start `module-` will be
 ignored. 
+
+Thus we can configure each subproject within such a multimodule project like this:
+
+```
+scmVersion {
+    tag {
+        prefix = "${project.name}"
+    }
+}
+```
 
 **IMPORTANT:**  
 
@@ -150,3 +160,5 @@ versions of any submodules.  If this is desired then consider wiring the `create
 # ./gradlew cV
 0.1.0
 ```
+
+For a multimodule project which has project lib dependencies (e.g. `moduleB` `dependsOn` `project(':moduleA')`), a change within `moduleA`'s code will result in the version of `moduleA` being incremented normally.  However, `moduleB`'s code may not have changed and thus it will not have its version incremented, which is usually not the desired behaviour.  This issue is rectified by the 2 tasks, `createReleaseDependents` and `releaseDependents`.  These tasks are analogous to `createRelease` and `release`, respectively, and traverse the inter-project dependency tree and cause the creation of releases for all projects that have a declared dependency on a project(s) whose code has changed.  Thus, for the example just cited, a new release would be created for `moduleB`.  This is modelled on how the Java plugin's `buildNeeded` and `buildDependents` tasks work (described [here](https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:multiproject_build_and_test)).

--- a/docs/configuration/tasks.md
+++ b/docs/configuration/tasks.md
@@ -1,13 +1,17 @@
 # Tasks
 
-`axion-gradle-plugin` adds 6 new Gradle tasks:
+`axion-gradle-plugin` adds 8* new Gradle tasks:
 
 -   *verifyRelease*
 -   *release*
 -   *createRelease*
+-   *releaseDependents*
+-   *createReleaseDependents*
 -   *pushRelease*
 -   *currentVersion*
 -   *markNextVersion*
+
+*The plugin also creates a helper task called `configureReleaseDependentsTasks` that is called internally, but this is not designed to be called by users.
 
 ## verifyRelease
 
@@ -28,6 +32,14 @@ of these tasks running exactly one after another.
 ## createRelease
 
 Run pre-release actions ([Pre/post release hooks](hooks.md)) and create release tag.
+
+## releaseDependents
+
+Works as per `release`, except that releases are created on any submodules that depend on the project in which this task is called, including transitive dependencies (i.e. changes to `moduleA` will generate releases for `moduleB` and `moduleC`, assuming `moduleC` depends on `moduleB` depends on `moduleA`).  This is described in further detail in [Basic Usage](../basic_usage.md).
+
+## createReleaseDependents
+
+Works as per `createRelease`, except that releases are created on any submodules that depend on the project in which this task is called, including transitive dependencies (i.e. changes to `moduleA` will generate releases for `moduleB` and `moduleC`, assuming `moduleC` depends on `moduleB` depends on `moduleA`).  This is described in further detail in [Basic Usage](../basic_usage.md).
 
 ## pushRelease
 

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectDependencyIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectDependencyIntegrationTest.groovy
@@ -1,0 +1,407 @@
+package pl.allegro.tech.build.axion.release
+
+import org.gradle.testkit.runner.TaskOutcome
+
+import java.util.stream.Collectors
+
+class MultiModuleProjectDependencyIntegrationTest extends BaseIntegrationTest {
+
+    File getSubmoduleDir(String projectName) {
+        return new File(temporaryFolder.root, projectName)
+    }
+
+    void generateSubmoduleBuildFile(String projectName) {
+        File submoduleDir = getSubmoduleDir(projectName)
+        submoduleDir.mkdirs()
+        File buildFile = new File(submoduleDir, "build.gradle")
+        buildFile << """
+        plugins {
+            id 'pl.allegro.tech.build.axion-release'
+        }
+
+        scmVersion {
+            tag {
+                prefix = '${projectName}'
+            }
+        }
+
+        project.version = scmVersion.version
+        """
+    }
+
+    void generateSettingsFile(File dir, List<String> submodules) {
+        String submodulesIncludeString = submodules.stream().map({ m -> "'${m}'" }).collect(Collectors.joining(','))
+        File settings = new File(dir, "settings.gradle")
+        settings << """
+        include ${submodulesIncludeString}
+
+        """
+    }
+
+    void generateGitIgnoreFile(File dir) {
+        File gitIgnore = new File(dir, ".gitignore")
+        gitIgnore << """\
+        .gradle
+        """.stripIndent()
+    }
+
+    /**
+     * Configure the multi-module project for testing.
+     * We start off with v1.0.0 on the parent project and versions 2.0.0, 3.0.0 and 4.0.0 for the 3 child projects.
+     * project2 depends on project1, project3 depends on project2
+     */
+    void initialProjectConfiguration() {
+        List<String> submodules = ["project1", "project2", "project3"]
+        buildFile('''
+        plugins {
+            id 'java'
+        }
+        scmVersion {
+            monorepos {
+                projectDirs = project.subprojects.collect({p -> p.name})
+            }
+        }
+        subprojects {
+            apply plugin: 'java'
+        }
+        project(":project2") {
+            dependencies {
+                implementation project(':project1')
+            }
+        }
+        project(":project3") {
+            dependencies {
+                implementation project(':project2')
+            }
+        }
+        '''
+        )
+        generateSettingsFile(temporaryFolder.root, submodules)
+        generateGitIgnoreFile(temporaryFolder.root)
+
+        repository.commit(['.'], "initial commit of top level project")
+
+        // create version for main project
+        runGradle(':createRelease', '-Prelease.version=1.0.0', '-Prelease.disableChecks')
+
+        // create submodules
+        int versionCounter = 2
+        for (String module : submodules) {
+            // generate the project files
+            generateSubmoduleBuildFile(module)
+            // add to repo
+            repository.commit(["${module}".toString()], "commit submodule ${module}".toString())
+            // tag release for that project
+            runGradle(":${module}:createRelease", "-Prelease.version=${versionCounter}.0.0", '-Prelease.disableChecks')
+            versionCounter++
+        }
+    }
+
+    def "plugin can distinguish between submodules versions"() {
+        given:
+        initialProjectConfiguration()
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project3:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.0'
+        result.task(":project3:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+    def "releaseDependents and change to dependent submodule should not change root or upstream submodule versions"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project2"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project2"], "commit submodule project2")
+        runGradle(":project2:releaseDependents", "-Prelease.version=5.0.0", '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '5.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+   def "releaseDependents and change to upstream submodule should force increment dependent module version despite no changes there"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project1"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project1"], "commit submodule project1")
+        runGradle(":project1:releaseDependents", '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.1'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.1'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project3:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.1'
+        result.task(":project3:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+    def "releaseDependents and change to submodule should not change root project version"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project1"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project1"], "commit submodule project1")
+        runGradle(":project1:releaseDependents", "-Prelease.version=4.0.0", '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "releaseDependents and change to root project should not change child project versions"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(temporaryFolder.root, "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["dummy.txt"], "commit parent project")
+        runGradle(":releaseDependents", "-Prelease.version=4.0.0", '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project3:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.0'
+        result.task(":project3:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+    def "createReleaseDependents and change to dependent submodule should not change root or upstream submodule versions"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project2"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project2"], "commit submodule project2")
+        runGradle(":project2:createReleaseDependents", "-Prelease.version=5.0.0", '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '5.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+    def "createReleaseDependents and change to upstream submodule should force increment dependent module version despite no changes there"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project1"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project1"], "commit submodule project1")
+        runGradle(":project1:createReleaseDependents", '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.1'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.1'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project3:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.1'
+        result.task(":project3:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+
+    def "createReleaseDependents and change to submodule should not change root project version"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(getSubmoduleDir("project1"), "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["project1"], "commit submodule project1")
+        runGradle(":project1:createReleaseDependents", "-Prelease.version=4.0.0", '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '1.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "createReleaseDependents and change to root project should not change child project versions"() {
+        given:
+        initialProjectConfiguration()
+        File dummy = new File(temporaryFolder.root, "dummy.txt")
+        dummy.createNewFile()
+        repository.commit(["dummy.txt"], "commit parent project")
+        runGradle(":createReleaseDependents", "-Prelease.version=4.0.0", '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle(':currentVersion')
+        def match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.0'
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project1:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '2.0.0'
+        result.task(":project1:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project2:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '3.0.0'
+        result.task(":project2:currentVersion").outcome == TaskOutcome.SUCCESS
+
+        when:
+        result = runGradle(':project3:currentVersion')
+        match = result.output =~ /(?m)^.*Project version: (.*)$/
+
+        then:
+        match[0][1] == '4.0.0'
+        result.task(":project3:currentVersion").outcome == TaskOutcome.SUCCESS
+
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ConfigureReleaseTasksTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ConfigureReleaseTasksTask.groovy
@@ -1,0 +1,63 @@
+package pl.allegro.tech.build.axion.release
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.TaskDependency
+import pl.allegro.tech.build.axion.release.domain.VersionConfig
+import pl.allegro.tech.build.axion.release.domain.VersionContext
+import pl.allegro.tech.build.axion.release.domain.VersionService
+import pl.allegro.tech.build.axion.release.infrastructure.di.Context
+import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
+
+/**
+ * Task that should set forceIncrementVersion within CreateReleaseTask and ReleaseTask.
+ */
+class ConfigureReleaseTasksTask extends DefaultTask {
+
+    @Optional
+    VersionConfig versionConfig
+
+    @TaskAction
+    void configureReleaseTasks() {
+        // by default, do not increment the version
+        ext.shouldForceIncrementVersion = false
+
+        // determine if there are any changes in this project
+        VersionConfig config = GradleAwareContext.configOrCreateFromProject(project, versionConfig)
+        Context context = GradleAwareContext.create(project, config)
+        VersionService versionService = context.versionService()
+        VersionContext versionContext = versionService.currentVersion(
+            context.rules().getVersion(), context.rules().getTag(), context.rules().getNextVersion()
+        )
+        if (versionContext.isSnapshot()) {
+            ext.shouldForceIncrementVersion = true
+        } else {
+            // if there are no changes in this project then we need to check upstream projects for changes
+            final Configuration configuration = project.getConfigurations().findByName(ReleasePlugin.TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+            if (configuration != null) {
+                TaskDependency taskDependency = configuration.getTaskDependencyFromProjectDependency(true, ReleasePlugin.CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK)
+                for (Task depTask : taskDependency.getDependencies()) {
+                    if (depTask.shouldForceIncrementVersion) {
+                        // upstream change detected, we should increment the version, no need to check any more
+                        ext.shouldForceIncrementVersion = true
+                        break
+                    }
+                }
+            }
+        }
+
+        // now configure the release tasks to force increment the version if a change was detected upstream
+        // if there was a change in this project then the project will be released normally, not forced
+        if (!versionContext.isSnapshot()) {
+            ReleaseTask releaseTask = (ReleaseTask) getProject().tasks.findByName(ReleasePlugin.RELEASE_TASK)
+            releaseTask?.setForceIncrementVersion(shouldForceIncrementVersion)
+
+            CreateReleaseTask createReleaseTask = (CreateReleaseTask) getProject().tasks.findByName(ReleasePlugin.CREATE_RELEASE_TASK)
+            createReleaseTask?.setForceIncrementVersion(shouldForceIncrementVersion)
+        }
+    }
+
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/CreateReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/CreateReleaseTask.groovy
@@ -10,15 +10,21 @@ import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
 class CreateReleaseTask extends DefaultTask {
 
+    boolean forceIncrementVersion = false
+
     @Optional
     VersionConfig versionConfig
 
     @TaskAction
     void release() {
         VersionConfig config = GradleAwareContext.configOrCreateFromProject(project, versionConfig)
-        Context context = GradleAwareContext.create(project, config)
+        Context context = GradleAwareContext.create(project, config, forceIncrementVersion)
         Releaser releaser = context.releaser()
-        releaser.release(context.rules())
+        println "forceIncrementVersion " + forceIncrementVersion
+        releaser.release(context.projectRootRelativePath(), context.rules(), forceIncrementVersion)
     }
 
+    void setForceIncrementVersion(boolean forceIncrementVersion) {
+        this.forceIncrementVersion = forceIncrementVersion
+    }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/MarkNextVersionTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/MarkNextVersionTask.groovy
@@ -19,10 +19,10 @@ class MarkNextVersionTask extends DefaultTask {
         VersionConfig config = GradleAwareContext.configOrCreateFromProject(project, versionConfig)
         Context context = GradleAwareContext.create(project, config)
 
-        NextVersionMarker marker = new NextVersionMarker(context.scmService())
-
         Properties rules = context.rules()
-        marker.markNextVersion(rules.nextVersion, rules.tag, config)
+        NextVersionMarker marker = new NextVersionMarker(context.scmService(), rules.getVersion().getMonorepoProperties().getDirsToExclude())
+
+        marker.markNextVersion(context.projectRootRelativePath(), rules.nextVersion, rules.tag, config)
     }
 
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -1,8 +1,10 @@
 package pl.allegro.tech.build.axion.release
 
+import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
 
 class ReleasePlugin implements Plugin<Project> {
@@ -22,6 +24,16 @@ class ReleasePlugin implements Plugin<Project> {
     public static final String CURRENT_VERSION_TASK = 'currentVersion'
 
     public static final String DRY_RUN_FLAG = 'release.dryRun'
+
+    private static final String RELEASE_GROUP = "Release"
+
+    public static final String RELEASE_DEPENDENTS_TASK = "releaseDependents"
+
+    public static final String CREATE_RELEASE_DEPENDENTS_TASK = "createReleaseDependents"
+
+    public static final String CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK = "configureReleaseDependentsTasks"
+
+    public static final String TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME = "testRuntimeClasspath";
 
     @Override
     void apply(Project project) {
@@ -52,5 +64,89 @@ class ReleasePlugin implements Plugin<Project> {
         Task currentVersionTask = project.tasks.create(CURRENT_VERSION_TASK, OutputCurrentVersionTask)
         currentVersionTask.group = 'Help'
         currentVersionTask.description = 'Prints current project version extracted from SCM.'
+
+        registerReleaseDependentTasks(project)
+
+        registerConfigureReleaseTasksTask(project)
     }
+
+    /**
+     * Create releaseDependents and createReleaseDependents tasks.
+     * The tasks should depend on the release task and be set as a dependency for all project tasks that
+     * depend on this project.
+     * @param project the project in which to register the tasks.
+     */
+    void registerReleaseDependentTasks(Project project) {
+        project.getTasks().register(CREATE_RELEASE_DEPENDENTS_TASK, new Action<Task>() {
+            @Override
+            void execute(Task task) {
+                task.setDescription("Creates a release for this project and all dependent projects")
+                task.setGroup(RELEASE_GROUP)
+                task.dependsOn(CREATE_RELEASE_TASK)
+                addDependsOnTaskInOtherProjects(task, false,
+                    CREATE_RELEASE_DEPENDENTS_TASK, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+                // configure this task to depend on configureReleaseDependentsTasks
+                task.dependsOn(CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK)
+            }
+        })
+        project.getTasks().register(RELEASE_DEPENDENTS_TASK, new Action<Task>() {
+            @Override
+            void execute(Task task) {
+                task.setDescription("Creates and pushes a release for this project and all dependent projects")
+                task.setGroup(RELEASE_GROUP)
+                task.dependsOn(RELEASE_TASK)
+                addDependsOnTaskInOtherProjects(task, false,
+                    RELEASE_DEPENDENTS_TASK, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+                // configure this task to depend on configureReleaseDependentsTasks
+                task.dependsOn(CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK)
+            }
+        })
+    }
+
+    /**
+     * Register configureReleaseDependentsTasks task.
+     * The task will fire before release.
+     * @param project the project in which to register the tasks.
+     */
+    void registerConfigureReleaseTasksTask(Project project) {
+        project.getTasks().register(CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK, ConfigureReleaseTasksTask, new Action<Task>() {
+            @Override
+            void execute(Task task) {
+                task.setDescription("Configures the releaseDependents and createReleaseDependents tasks to increment the release version")
+                task.setGroup(RELEASE_GROUP)
+
+                // createReleaseDependents will cause createRelease to fire, so set this task to fire before createRelease
+                task.getProject().getTasks().findByName(CREATE_RELEASE_TASK).configure {
+                    mustRunAfter(task)
+                }
+                // releaseDependents will cause release to fire, so set this task to fire before release
+                task.getProject().getTasks().findByName(RELEASE_TASK).configure {
+                    mustRunAfter(task)
+                }
+                // configure this task to depend on all similar tasks in upstream projects
+                addDependsOnTaskInOtherProjects(task, true,
+                    CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+            }
+        })
+    }
+
+    /**
+     * Adds a dependency on tasks with the specified name in other projects.  The other projects are determined from
+     * project lib dependencies using the specified configuration name. These may be projects this project depends on or
+     * projects that depend on this project based on the useDependOn argument.
+     *
+     * @param task Task to add dependencies to
+     * @param useDependedOn if true, add tasks from projects this project depends on, otherwise use projects that depend on this one.
+     * @param otherProjectTaskName name of task in other projects
+     * @param configurationName name of configuration to use to find the other projects. If the configuration does not exist then no dependency will be added.
+     */
+    private void addDependsOnTaskInOtherProjects(final Task task, boolean useDependedOn, String otherProjectTaskName,
+                                                 String configurationName) {
+        Project project = task.getProject()
+        final Configuration configuration = project.getConfigurations().findByName(configurationName)
+        if (configuration != null) {
+            task.dependsOn(configuration.getTaskDependencyFromProjectDependency(useDependedOn, otherProjectTaskName))
+        }
+    }
+
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -68,6 +68,8 @@ class ReleasePlugin implements Plugin<Project> {
         registerReleaseDependentTasks(project)
 
         registerConfigureReleaseTasksTask(project)
+
+        configureReleaseOrder(project)
     }
 
     /**
@@ -147,6 +149,16 @@ class ReleasePlugin implements Plugin<Project> {
         if (configuration != null) {
             task.dependsOn(configuration.getTaskDependencyFromProjectDependency(useDependedOn, otherProjectTaskName))
         }
+    }
+
+    /**
+     * Configures a dummy output directory for the release task so that release tasks all share this and will not run in parallel.
+     * @param project project in which to configure the release task.
+     */
+    void configureReleaseOrder(Project project) {
+        Task release = project.getTasks().getByName(RELEASE_TASK)
+        release.outputs.dir "${project.rootProject.buildDir}/commonReleaseDummyOutput"
+        release.outputs.upToDateWhen {false}
     }
 
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -74,8 +74,8 @@ class ReleasePlugin implements Plugin<Project> {
 
     /**
      * Create releaseDependents and createReleaseDependents tasks.
-     * The tasks should depend on the release task and be set as a dependency for all project tasks that
-     * depend on this project.
+     * The tasks should depend on the release task and the same task in all project tasks that
+     * depend this project depends on.
      * @param project the project in which to register the tasks.
      */
     void registerReleaseDependentTasks(Project project) {
@@ -85,7 +85,7 @@ class ReleasePlugin implements Plugin<Project> {
                 task.setDescription("Creates a release for this project and all dependent projects")
                 task.setGroup(RELEASE_GROUP)
                 task.dependsOn(CREATE_RELEASE_TASK)
-                addDependsOnTaskInOtherProjects(task, false,
+                addDependsOnTaskInOtherProjects(task, true,
                     CREATE_RELEASE_DEPENDENTS_TASK, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
                 // configure this task to depend on configureReleaseDependentsTasks
                 task.dependsOn(CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK)
@@ -97,7 +97,7 @@ class ReleasePlugin implements Plugin<Project> {
                 task.setDescription("Creates and pushes a release for this project and all dependent projects")
                 task.setGroup(RELEASE_GROUP)
                 task.dependsOn(RELEASE_TASK)
-                addDependsOnTaskInOtherProjects(task, false,
+                addDependsOnTaskInOtherProjects(task, true,
                     RELEASE_DEPENDENTS_TASK, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
                 // configure this task to depend on configureReleaseDependentsTasks
                 task.dependsOn(CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK)
@@ -125,7 +125,7 @@ class ReleasePlugin implements Plugin<Project> {
                 task.getProject().getTasks().findByName(RELEASE_TASK).configure {
                     mustRunAfter(task)
                 }
-                // configure this task to depend on all similar tasks in upstream projects
+                // configure this task to depend on all similar tasks in projects that depend on this one
                 addDependsOnTaskInOtherProjects(task, true,
                     CONFIGURE_RELEASE_DEPENDENTS_TASKS_TASK, TEST_RUNTIME_CLASSPATH_CONFIGURATION_NAME)
             }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseTask.groovy
@@ -11,15 +11,17 @@ import pl.allegro.tech.build.axion.release.infrastructure.di.GradleAwareContext
 
 class ReleaseTask extends DefaultTask {
 
+    boolean forceIncrementVersion = false
+
     @Optional
     VersionConfig versionConfig
 
     @TaskAction
     void release() {
         VersionConfig config = GradleAwareContext.configOrCreateFromProject(project, versionConfig)
-        Context context = GradleAwareContext.create(project, config)
+        Context context = GradleAwareContext.create(project, config, forceIncrementVersion)
         Releaser releaser = context.releaser()
-        ScmPushResult result = releaser.releaseAndPush(context.rules())
+        ScmPushResult result = releaser.releaseAndPush(context.projectRootRelativePath(), context.rules(), forceIncrementVersion)
 
         if(!result.success) {
             def message = result.remoteMessage.orElse("Unknown error during push")
@@ -30,5 +32,9 @@ class ReleaseTask extends DefaultTask {
 
     void setVersionConfig(VersionConfig versionConfig) {
         this.versionConfig = versionConfig
+    }
+
+    void setForceIncrementVersion(boolean forceIncrementVersion) {
+        this.forceIncrementVersion = forceIncrementVersion
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarker.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarker.groovy
@@ -11,12 +11,18 @@ class NextVersionMarker {
     private static final ReleaseLogger logger = ReleaseLogger.Factory.logger(NextVersionMarker)
 
     private final ScmService repositoryService
+    private final List<String> dirsToExclude;
 
     NextVersionMarker(ScmService repositoryService) {
-        this.repositoryService = repositoryService
+        this(repositoryService, Collections.emptyList());
     }
 
-    void markNextVersion(NextVersionProperties nextVersionRules, TagProperties tagRules, VersionConfig versionConfig) {
+    NextVersionMarker(ScmService repositoryService, List<String> dirsToExclude) {
+        this.repositoryService = repositoryService
+        this.dirsToExclude = dirsToExclude;
+    }
+
+    void markNextVersion(String projectRootRelativePath, NextVersionProperties nextVersionRules, TagProperties tagRules, VersionConfig versionConfig) {
 
         String nextVersion = null
         if (nextVersionRules.nextVersion) {
@@ -34,7 +40,7 @@ class NextVersionMarker {
         String nextVersionTag = nextVersionRules.serializer(nextVersionRules, tagName)
 
         logger.quiet("Creating next version marker tag: $nextVersionTag")
-        repositoryService.tag(nextVersionTag)
+        repositoryService.tag(repositoryService.positionOfLastChangeIn(projectRootRelativePath, dirsToExclude).getRevision(), nextVersionTag)
         repositoryService.push()
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -28,11 +28,11 @@ class DryRepository implements ScmRepository {
 
     @Override
     void tag(String tagName) {
-        log("creating tag with name: $tagName")
+        tag("HEAD", tagName)
     }
 
     @Override
-    void tagOnCommit(String revision, String tagName) {
+    void tag(String revision, String tagName) {
         log("creating tag with name: $tagName on commit ${revision}")
     }
 
@@ -64,7 +64,7 @@ class DryRepository implements ScmRepository {
 
     @Override
     ScmPosition positionOfLastChangeIn(String path, List<String> excludeSubFolders) {
-        return delegateRepository.positionOfLastChangeIn(path)
+        return delegateRepository.positionOfLastChangeIn(path, excludeSubFolders)
     }
 
     @Override

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DryRepository.groovy
@@ -32,6 +32,11 @@ class DryRepository implements ScmRepository {
     }
 
     @Override
+    void tagOnCommit(String revision, String tagName) {
+        log("creating tag with name: $tagName on commit ${revision}")
+    }
+
+    @Override
     void dropTag(String tagName) {
         log("dropping tag with name: $tagName")
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -32,6 +32,11 @@ class DummyRepository implements ScmRepository {
     }
 
     @Override
+    void tagOnCommit(String revision, String tagName) {
+        log('create tag')
+    }
+
+    @Override
     void dropTag(String tagName) {
         log('drop tag')
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -28,11 +28,11 @@ class DummyRepository implements ScmRepository {
 
     @Override
     void tag(String tagName) {
-        log('create tag')
+        tag("HEAD", 'tag')
     }
 
     @Override
-    void tagOnCommit(String revision, String tagName) {
+    void tag(String revision, String tagName) {
         log('create tag')
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/RulesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/RulesFactory.groovy
@@ -8,10 +8,10 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 
 class RulesFactory {
 
-    static Properties create(Project project, VersionConfig versionConfig, ScmPosition position) {
+    static Properties create(Project project, VersionConfig versionConfig, ScmPosition position, boolean shouldForceIncrementVersion) {
         return new Properties(
             project.hasProperty(ReleasePlugin.DRY_RUN_FLAG),
-            VersionPropertiesFactory.create(project, versionConfig, position.branch),
+            VersionPropertiesFactory.create(project, versionConfig, position.branch, shouldForceIncrementVersion),
             TagPropertiesFactory.create(versionConfig.tag, position.branch),
             ChecksPropertiesFactory.create(project, versionConfig.checks),
             NextVersionPropertiesFactory.create(project, versionConfig.nextVersion),

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactory.groovy
@@ -24,7 +24,7 @@ class VersionPropertiesFactory {
 
     private static final String VERSION_CREATOR_PROPERTY = 'release.versionCreator'
 
-    static VersionProperties create(Project project, VersionConfig config, String currentBranch) {
+    static VersionProperties create(Project project, VersionConfig config, String currentBranch, boolean shouldForceIncrementVersion) {
         String forceVersionValue = project.hasProperty(FORCE_VERSION_PROPERTY) ? project.property(FORCE_VERSION_PROPERTY) : null
         if (forceVersionValue == null) {
             forceVersionValue = project.hasProperty(DEPRECATED_FORCE_VERSION_PROPERTY) ? project.property(DEPRECATED_FORCE_VERSION_PROPERTY) : null
@@ -43,7 +43,8 @@ class VersionPropertiesFactory {
             findVersionIncrementer(project, config, currentBranch),
             config.sanitizeVersion,
             useHighestVersion,
-            MonorepoPropertiesFactory.create(project, config.monorepoConfig, currentBranch)
+            MonorepoPropertiesFactory.create(project, config.monorepoConfig, currentBranch),
+            shouldForceIncrementVersion
         )
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/Context.groovy
@@ -23,14 +23,17 @@ class Context {
 
     private final LocalOnlyResolver localOnlyResolver
 
+    private final String projectRootRelativePath
+
     Context(Properties rules, ScmRepository scmRepository, ScmProperties scmProperties, File projectRoot, LocalOnlyResolver localOnlyResolver) {
         this.rules = rules
         this.scmRepository = scmRepository
         this.scmProperties = scmProperties
         this.localOnlyResolver = localOnlyResolver
+        this.projectRootRelativePath = scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString()
 
         instances[ScmRepository] = scmRepository
-        instances[VersionService] = new VersionService(new VersionResolver(scmRepository, scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString()))
+        instances[VersionService] = new VersionService(new VersionResolver(scmRepository, projectRootRelativePath))
     }
 
     private <T> T get(Class<T> clazz) {
@@ -67,5 +70,9 @@ class Context {
 
     ScmChangesPrinter changesPrinter() {
         return new GitChangesPrinter(get(ScmRepository) as GitRepository)
+    }
+
+    String projectRootRelativePath() {
+        return projectRootRelativePath
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/GradleAwareContext.groovy
@@ -11,11 +11,15 @@ import pl.allegro.tech.build.axion.release.infrastructure.config.ScmPropertiesFa
 class GradleAwareContext {
 
     static Context create(Project project, VersionConfig versionConfig) {
+        return create(project, versionConfig, false)
+    }
+
+    static Context create(Project project, VersionConfig versionConfig, boolean shouldForceIncrementVersion) {
         ScmProperties scmProperties = ScmPropertiesFactory.create(project, versionConfig)
         ScmRepository scmRepository = ScmRepositoryFactory.create(scmProperties)
 
         return new Context(
-            RulesFactory.create(project, versionConfig, scmRepository.currentPosition()),
+            RulesFactory.create(project, versionConfig, scmRepository.currentPosition(), shouldForceIncrementVersion),
             scmRepository,
             scmProperties,
             project.projectDir,

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
@@ -34,14 +34,9 @@ public class Releaser {
             hooksRunner.runPreReleaseHooks(properties.getHooks(), properties, versionContext, version);
 
             logger.quiet("Creating tag: " + tagName);
-            // if snapshot then release normally, otherwise release tag on last commit that is relevant to this project
-            if (versionContext.isSnapshot()) {
-                repository.tag(tagName);
-            } else {
-                repository.tagOnCommit(repository.positionOfLastChangeIn(projectRootRelativePath,
-                    properties.getVersion().getMonorepoProperties().getDirsToExclude()
-                ).getRevision(), tagName);
-            }
+            repository.tag(repository.positionOfLastChangeIn(projectRootRelativePath,
+                properties.getVersion().getMonorepoProperties().getDirsToExclude()
+            ).getRevision(), tagName);
 
             hooksRunner.runPostReleaseHooks(properties.getHooks(), properties, versionContext, version);
             return Optional.of(tagName);

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
@@ -4,7 +4,6 @@ import com.github.zafarkhaja.semver.Version;
 import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHooksRunner;
 import pl.allegro.tech.build.axion.release.domain.logging.ReleaseLogger;
 import pl.allegro.tech.build.axion.release.domain.properties.Properties;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult;
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService;
 
@@ -37,11 +36,8 @@ public class Releaser {
             logger.quiet("Creating tag: " + tagName);
             // if snapshot then release normally, otherwise release tag on last commit that is relevant to this project
             if (versionContext.isSnapshot()) {
-                System.out.println("isSnapshot");
                 repository.tag(tagName);
             } else {
-                System.out.println("not isSnapshot");
-
                 repository.tagOnCommit(repository.positionOfLastChangeIn(projectRootRelativePath,
                     properties.getVersion().getMonorepoProperties().getDirsToExclude()
                 ).getRevision(), tagName);

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionFactory.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionFactory.java
@@ -59,7 +59,7 @@ public class VersionFactory {
 
         boolean isSnapshot = forceVersionShouldForceSnapshot || versionProperties.isForceSnapshot() || hasChanges || scmState.isOnNextVersionTag() || scmState.isNoReleaseTagsFound();
         boolean proposedVersionIsAlreadySnapshot = scmState.isOnNextVersionTag() || scmState.isNoReleaseTagsFound();
-        boolean incrementVersion = ((versionProperties.isForceSnapshot() || hasChanges) && !proposedVersionIsAlreadySnapshot);
+        boolean incrementVersion = ((versionProperties.isForceSnapshot() || hasChanges || versionProperties.isShouldForceIncrementVersion()) && !proposedVersionIsAlreadySnapshot);
 
         Version finalVersion = version;
         if (StringGroovyMethods.asBoolean(versionProperties.getForcedVersion())) {

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.java
@@ -13,6 +13,7 @@ public class VersionProperties {
     private final boolean sanitizeVersion;
     private final boolean useHighestVersion;
     private final MonorepoProperties monorepoProperties;
+    private final boolean shouldForceIncrementVersion;
 
     public VersionProperties(
         String forcedVersion,
@@ -22,7 +23,8 @@ public class VersionProperties {
         Closure<Version> versionIncrementer,
         boolean sanitizeVersion,
         boolean useHighestVersion,
-        MonorepoProperties monorepoProperties
+        MonorepoProperties monorepoProperties,
+        boolean shouldForceIncrementVersion
     ) {
         this.forcedVersion = forcedVersion;
         this.forceSnapshot = forceSnapshot;
@@ -32,6 +34,7 @@ public class VersionProperties {
         this.sanitizeVersion = sanitizeVersion;
         this.useHighestVersion = useHighestVersion;
         this.monorepoProperties = monorepoProperties;
+        this.shouldForceIncrementVersion = shouldForceIncrementVersion;
     }
 
     public boolean forceVersion() {
@@ -68,5 +71,9 @@ public class VersionProperties {
 
     public MonorepoProperties getMonorepoProperties() {
         return monorepoProperties;
+    }
+
+    public boolean isShouldForceIncrementVersion() {
+        return shouldForceIncrementVersion;
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.java
@@ -9,6 +9,8 @@ public interface ScmRepository {
 
     void tag(String tagName);
 
+    void tagOnCommit(String revision, String tagName);
+
     void dropTag(String tagName);
 
     ScmPushResult push(ScmIdentity identity, ScmPushOptions pushOptions);

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.java
@@ -9,7 +9,7 @@ public interface ScmRepository {
 
     void tag(String tagName);
 
-    void tagOnCommit(String revision, String tagName);
+    void tag(String revision, String tagName);
 
     void dropTag(String tagName);
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmService.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmService.java
@@ -23,8 +23,8 @@ public class ScmService {
         repository.tag(tagName);
     }
 
-    public void tagOnCommit(String revision, String tagName) {
-        repository.tagOnCommit(revision, tagName);
+    public void tag(String revision, String tagName) {
+        repository.tag(revision, tagName);
     }
 
     public void dropTag(String tagName) {

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmService.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmService.java
@@ -23,6 +23,10 @@ public class ScmService {
         repository.tag(tagName);
     }
 
+    public void tagOnCommit(String revision, String tagName) {
+        repository.tagOnCommit(revision, tagName);
+    }
+
     public void dropTag(String tagName) {
         try {
             repository.dropTag(tagName);
@@ -50,6 +54,16 @@ public class ScmService {
 
     public ScmPosition position() {
         return repository.currentPosition();
+    }
+
+    /**
+     * Find the last commit that occurred within a certain subdirectory of the project.
+     * @param path Path to look at for commits
+     * @param excludeSubFolders Subfolders within the search path to ignore, generally because they are subprojects themselves.
+     * @return ScmPosition representing the last commit in the given search path.
+     */
+    public ScmPosition positionOfLastChangeIn(String path, List<String> excludeSubFolders) {
+        return repository.positionOfLastChangeIn(path, excludeSubFolders);
     }
 
     public void commit(List patterns, String message) {

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -75,34 +75,14 @@ public class GitRepository implements ScmRepository {
     @Override
     public void tag(final String tagName) {
         try {
-            final String headId = head().name();
-            List<Ref> tags = jgitRepository.tagList().call();
-
-            boolean isOnExistingTag = tags.stream().anyMatch(ref -> {
-                boolean onTag = ref.getName().equals(GIT_TAG_PREFIX + tagName);
-                boolean onHead;
-                try {
-                    onHead = jgitRepository.getRepository().getRefDatabase()
-                        .peel(ref).getPeeledObjectId().getName().equals(headId);
-                } catch (IOException e) {
-                    throw new ScmException(e);
-                }
-
-                return onTag && onHead;
-            });
-
-            if (!isOnExistingTag) {
-                jgitRepository.tag().setName(tagName).call();
-            } else {
-                logger.debug("The head commit " + headId + " already has the tag " + tagName + ".");
-            }
-        } catch (GitAPIException | IOException e) {
+            tag(head().name(), tagName);
+        }  catch (IOException e) {
             throw new ScmException(e);
         }
     }
 
     @Override
-    public void tagOnCommit(final String revision, final String tagName) {
+    public void tag(final String revision, final String tagName) {
         try {
             ObjectId commitId = ObjectId.fromString(revision);
             RevWalk revWalk = new RevWalk(jgitRepository.getRepository());

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
@@ -40,7 +40,7 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
         NextVersionProperties rules = nextVersionProperties().withNextVersion('2.0.0').build()
 
         when:
-        nextVersionMarker.markNextVersion(rules, tagRules, config)
+        nextVersionMarker.markNextVersion("", rules, tagRules, config)
 
         then:
         repository.latestTags(~/.*/).tags == ['release-2.0.0-alpha']
@@ -52,7 +52,7 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
         NextVersionProperties rules = nextVersionProperties().build()
 
         when:
-        nextVersionMarker.markNextVersion(rules, tagRules, config)
+        nextVersionMarker.markNextVersion("", rules, tagRules, config)
 
         then:
         repository.latestTags(~/.*/).tags == ['release-0.1.1-alpha']
@@ -66,7 +66,7 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
             .build()
 
         when:
-        nextVersionMarker.markNextVersion(rules, tagRules, config)
+        nextVersionMarker.markNextVersion("", rules, tagRules, config)
 
         then:
         repository.latestTags(~/.*/).tags == ['release-1.0.0-alpha']

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ReleaserTest.groovy
@@ -28,7 +28,7 @@ class ReleaserTest extends RepositoryBasedTest {
                 .build()
 
         when:
-        releaser.release(rules)
+        releaser.release(context.projectRootRelativePath(), rules, false)
 
         then:
         currentVersion() == '2.0.0'
@@ -39,7 +39,18 @@ class ReleaserTest extends RepositoryBasedTest {
         repository.tag('release-1.0.0')
 
         when:
-        releaser.release(context.rules())
+        releaser.release(context.projectRootRelativePath(), context.rules(), false)
+
+        then:
+        currentVersion() == '1.0.0'
+    }
+
+   def "should release version when on tag and shouldForceIncrement"() {
+        given:
+        repository.tag('release-1.0.0')
+
+        when:
+        releaser.release(context.projectRootRelativePath(), context.rules(), true)
 
         then:
         currentVersion() == '1.0.0'
@@ -53,7 +64,7 @@ class ReleaserTest extends RepositoryBasedTest {
                 .build()
 
         when:
-        releaser.release(rules)
+        releaser.release(context.projectRootRelativePath(), rules, false)
 
         then:
         currentVersion() == '3.0.0-rc4'
@@ -64,7 +75,18 @@ class ReleaserTest extends RepositoryBasedTest {
         repository.tag('release-3.0.0-rc4')
 
         when:
-        releaser.release(context.rules())
+        releaser.release(context.projectRootRelativePath(), context.rules(), false)
+
+        then:
+        currentVersion() == '3.0.0-rc4'
+    }
+
+    def "should release version when on pre-released version tag and shouldForceIncrement"() {
+        given:
+        repository.tag('release-3.0.0-rc4')
+
+        when:
+        releaser.release(context.projectRootRelativePath(), context.rules(), true)
 
         then:
         currentVersion() == '3.0.0-rc4'
@@ -76,7 +98,7 @@ class ReleaserTest extends RepositoryBasedTest {
         repository.commit(['*'], 'make is snapshot')
 
         when:
-        releaser.release(context.rules())
+        releaser.release(context.projectRootRelativePath(), context.rules(), false)
 
         then:
         currentVersion() == '3.0.1'
@@ -90,7 +112,7 @@ class ReleaserTest extends RepositoryBasedTest {
                 .build()
 
         when:
-        releaser.release(rules)
+        releaser.release(context.projectRootRelativePath(), rules, false)
 
         then:
         currentVersion() == '3.0.0'
@@ -106,7 +128,7 @@ class ReleaserTest extends RepositoryBasedTest {
                 .build()
 
         when:
-        releaser.release(rules)
+        releaser.release(context.projectRootRelativePath(), rules, false)
 
         then:
         currentVersion() == '3.2.0'

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionFactoryTest.groovy
@@ -108,6 +108,18 @@ class VersionFactoryTest extends Specification {
         version.snapshot
     }
 
+    def "should increment patch version when on release tag if forceIncrementVersion is set"() {
+        given:
+        VersionFactory factory = versionFactory(versionProperties().forceIncrementVersion().build())
+
+        when:
+        VersionFactory.FinalVersion version = factory.createFinalVersion(scmState().onReleaseTag().build(), Version.valueOf('1.0.0'))
+
+        then:
+        version.version.toString() == '1.0.1'
+        !version.snapshot
+    }
+
     def "should not increment patch version when on tag and there are uncommitted changes but they are ignored (default)"() {
         when:
         VersionFactory.FinalVersion version = factory.createFinalVersion(scmState().onReleaseTag().hasUncomittedChanges().build(), Version.valueOf('1.0.0'))

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionPropertiesBuilder.groovy
@@ -19,6 +19,8 @@ class VersionPropertiesBuilder {
 
     private boolean sanitizeVersion = true
 
+    private boolean shouldForceIncrement = false;
+
     private VersionPropertiesBuilder() {
     }
 
@@ -35,7 +37,8 @@ class VersionPropertiesBuilder {
             PredefinedVersionIncrementer.versionIncrementerFor('incrementPatch'),
             sanitizeVersion,
             useHighestVersion,
-            monorepoProperties
+            monorepoProperties,
+            shouldForceIncrement
         )
     }
 
@@ -58,7 +61,7 @@ class VersionPropertiesBuilder {
         this.useHighestVersion = true
         return this
     }
-    
+
     VersionPropertiesBuilder supportMonorepos(MonorepoProperties monorepoProperties) {
         this.monorepoProperties = monorepoProperties
         return this
@@ -71,6 +74,11 @@ class VersionPropertiesBuilder {
 
     VersionPropertiesBuilder dontSanitizeVersion() {
         this.sanitizeVersion = false
+        return this
+    }
+
+    VersionPropertiesBuilder forceIncrementVersion()  {
+        this.shouldForceIncrement = true
         return this
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactoryTest.groovy
@@ -27,7 +27,7 @@ class VersionPropertiesFactoryTest extends Specification {
         versionConfig.sanitizeVersion = false
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         rules.versionIncrementer() == new Version.Builder('1.2.3').build()
@@ -36,7 +36,7 @@ class VersionPropertiesFactoryTest extends Specification {
 
     def "should return forceVersion false when project has no 'release.version' property"() {
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         !rules.forceVersion()
@@ -47,7 +47,7 @@ class VersionPropertiesFactoryTest extends Specification {
         project.extensions.extraProperties.set('release.version', '')
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         !rules.forceVersion()
@@ -58,7 +58,7 @@ class VersionPropertiesFactoryTest extends Specification {
         project.extensions.extraProperties.set('release.version', 'version')
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         rules.forceVersion()
@@ -70,7 +70,7 @@ class VersionPropertiesFactoryTest extends Specification {
         project.extensions.extraProperties.set('release.version', ' version ')
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         rules.forceVersion()
@@ -82,7 +82,7 @@ class VersionPropertiesFactoryTest extends Specification {
         project.extensions.extraProperties.set('release.forceVersion', 'version')
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         rules.forceVersion()
@@ -94,7 +94,7 @@ class VersionPropertiesFactoryTest extends Specification {
         versionConfig.ignoreUncommittedChanges = false
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         !rules.ignoreUncommittedChanges
@@ -106,7 +106,7 @@ class VersionPropertiesFactoryTest extends Specification {
         project.extensions.extraProperties.set('release.ignoreUncommittedChanges', true)
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         rules.ignoreUncommittedChanges
@@ -120,7 +120,7 @@ class VersionPropertiesFactoryTest extends Specification {
         ]
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         rules.versionCreator(null, null) == 'default'
@@ -134,7 +134,7 @@ class VersionPropertiesFactoryTest extends Specification {
         ]
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch', false)
 
         then:
         rules.versionCreator(null, null) == 'someBranch'
@@ -148,7 +148,7 @@ class VersionPropertiesFactoryTest extends Specification {
         ]
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch', false)
 
         then:
         rules.versionCreator('1.0.0', scmPosition('someBranch')) == '1.0.0-someBranch'
@@ -164,7 +164,7 @@ class VersionPropertiesFactoryTest extends Specification {
         project.extensions.extraProperties.set('release.versionCreator', 'simple')
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch', false)
 
         then:
         rules.versionCreator('1.0.0', scmPosition('someBranch')) == '1.0.0'
@@ -178,7 +178,7 @@ class VersionPropertiesFactoryTest extends Specification {
         ]
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', false)
 
         then:
         rules.versionIncrementer(
@@ -194,7 +194,7 @@ class VersionPropertiesFactoryTest extends Specification {
         ]
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch', false)
 
         then:
         rules.versionIncrementer(
@@ -210,7 +210,7 @@ class VersionPropertiesFactoryTest extends Specification {
         ]
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch', false)
 
         then:
         rules.versionIncrementer(
@@ -226,7 +226,7 @@ class VersionPropertiesFactoryTest extends Specification {
         ]
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch', false)
 
         then:
         rules.versionIncrementer(
@@ -240,7 +240,7 @@ class VersionPropertiesFactoryTest extends Specification {
         project.extensions.extraProperties.set('release.versionIncrementer', 'incrementMajor')
 
         when:
-        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch', false)
 
         then:
         rules.versionIncrementer(
@@ -248,4 +248,17 @@ class VersionPropertiesFactoryTest extends Specification {
         ) == Version.forIntegers(2)
 
     }
+
+    def "should set shouldForceIncrement if set"() {
+        given:
+        versionConfig.versionIncrementer = { new Version.Builder('1.2.3').build() }
+        versionConfig.sanitizeVersion = false
+
+        when:
+        VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master', true)
+
+        then:
+        rules.isShouldForceIncrementVersion()
+    }
+
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
@@ -23,7 +23,7 @@ class DryRepositoryTest extends Specification {
 
     def "should not create actual tags in scm on non-head"() {
         when:
-        dryRepository.tagOnCommit("some-rev","dry_tag")
+        dryRepository.tag("some-rev","dry_tag")
 
         then:
         0 * scm.tagOnCommit(_)

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/DryRepositoryTest.groovy
@@ -21,6 +21,14 @@ class DryRepositoryTest extends Specification {
         0 * scm.tag(_)
     }
 
+    def "should not create actual tags in scm on non-head"() {
+        when:
+        dryRepository.tagOnCommit("some-rev","dry_tag")
+
+        then:
+        0 * scm.tagOnCommit(_)
+    }
+
     def "should not push anything to scm"() {
         when:
         dryRepository.push(ScmIdentity.defaultIdentityWithoutAgents(), new ScmPushOptions('dry-remote', false))

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -66,7 +66,7 @@ class GitRepositoryTest extends Specification {
 
         when:
         repository.commit(['*'], "2nd commit")
-        repository.tagOnCommit(initialCommitRevision, 'release-1')
+        repository.tag(initialCommitRevision, 'release-1')
 
         then:
         rawRepository.describe(commit: initialCommitRevision, tags: true) == 'release-1'
@@ -79,8 +79,8 @@ class GitRepositoryTest extends Specification {
 
         when:
         repository.commit(['*'], "2nd commit")
-        repository.tagOnCommit(initialCommitRevision, 'release-1')
-        repository.tagOnCommit(initialCommitRevision, 'release-1')
+        repository.tag(initialCommitRevision, 'release-1')
+        repository.tag(initialCommitRevision, 'release-1')
 
         then:
         rawRepository.describe(commit: initialCommitRevision, tags: true) == 'release-1'

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -59,6 +59,33 @@ class GitRepositoryTest extends Specification {
         rawRepository.tag.list()*.fullName == ['refs/tags/release-1']
     }
 
+    def "should create new tag on non-head commit"() {
+        given:
+        String initialCommitRevision = rawRepository.log(maxCommits: 1)*.id.first()
+        println initialCommitRevision
+
+        when:
+        repository.commit(['*'], "2nd commit")
+        repository.tagOnCommit(initialCommitRevision, 'release-1')
+
+        then:
+        rawRepository.describe(commit: initialCommitRevision, tags: true) == 'release-1'
+    }
+
+    def "should not throw exception if attempting to recreate tag on non-head commit"() {
+        given:
+        String initialCommitRevision = rawRepository.log(maxCommits: 1)*.id.first()
+        println initialCommitRevision
+
+        when:
+        repository.commit(['*'], "2nd commit")
+        repository.tagOnCommit(initialCommitRevision, 'release-1')
+        repository.tagOnCommit(initialCommitRevision, 'release-1')
+
+        then:
+        rawRepository.describe(commit: initialCommitRevision, tags: true) == 'release-1'
+    }
+
     def "should create tag when on HEAD even if it already exists on the same commit"() {
         given:
         repository.tag('release-1')


### PR DESCRIPTION
Fixes #325 and #314: enables modules dependent on other submodules to have their version incremented, even if there are no code changes in that module.

There were two issues with the plugin when it handled multi-module projects:
- modules that depended on other modules did not have their version incremented if there were no code changes within that module.  There is no mechanism for force incrementing the version of a module.
- assuming that there were a mechanism for force incrementing a module's version given that its dependent modules' versions have changed, the release tag is placed on HEAD, not on the last relevant commit for that module (the commit closest to HEAD that occurred with changes within that module's directory).

This PR fixes these issues in a non-breaking manner.

The PR adds 2 additional top-level tasks, `createRelaseDependents` and `releaseDependents`, which are analogous to `createRelease` and `release` respectively.  For the purposes of this PR description, `releaseDependents` will be used, but `createReleaseDependents` operates in a similar manner.  The purpose of `releaseDependents` is to create a release for a module that has changed and also for all modules that rely on that module, and for this change to then be transitively cascaded down the dependency tree.

The current `release` mechanism is idempotent and this is a very nice feature and must be retained. Calling `releaseDependents` repeatedly should not cause multiple releases to be generated.

The `releaseDependents` task operates in an identical fashion to Gradle's Java plugin, which adds `buildNeeded` and `buildDependents` tasks, as described [here](https://docs.gradle.org/current/userguide/multi_project_builds.html#sec:multiproject_build_and_test).  Within each project, the `release` task is added as a dependency of `releaseDependents`, and that project's `releaseDependents` task is added as a dependency of all downstream projects.  Calling `releaseDependents` will thus cause `release` to be called in all downstream dependent projects.

In order to actually cause the release to be created, it is necessary for the `release` task to take account of whether upstream releases were created.  The plugin adds a task called `configureReleaseTasksTask` that is set as a dependency of `releaseDependents` and to run prior to `release`.  Calling `releaseDependents` will thus cause the following execution order: `configureReleaseTasksTask`, `release`, `releaseDependents`.  This task checks upstream tasks of the same name and determines if they released a new release by looking at an `ext` property on that task.  If any upstream task caused a release then the task will configure the `release` task to create a version.

We don't want a user to be able to mess up the idempotency of the release process through poor config, so there is a property within `VersionProperties` that determines whether a version should be force incremented (it is not parsed from config).  That property is set based on a flag in the `ReleaseTask` that is set by the `configureReleaseTasksTask` that runs before it.

If a project has changes then the normal release process will be followed.  If there are no changes then a release is created if the force increment flag is set. In this case, the new release tag is written to the last commit that relates to that project, which is not necessarily HEAD.  This ensures that the version resolution for these projects is correct as they are set up to ignore changes in directories that are not related to the project in question.

Here is an example of one of the `MultiModuleProjectDependencyIntegrationTest` unit tests showing where release tags are placed using this new process:

```
commit 8b8866eded61b593442403a058d91816893d043b (HEAD -> refs/heads/master, tag: refs/tags/project1-2.0.1)
  Author: John Tipper <john.tipper@example.com>
  Date:   Tue Jan 28 22:57:34 2020 +0000
  
      commit submodule project1
  
  commit 87ff9829a1b123dcec37f97998556a42d9e72b9e (tag: refs/tags/project3-4.0.1, tag: refs/tags/project3-4.0.0)
  Author: John Tipper <john.tipper@example.com>
  Date:   Tue Jan 28 22:57:34 2020 +0000
  
      commit submodule project3
  
  commit 6cd13c3a838d80c87761d6afe27f8f4566f1d372 (tag: refs/tags/project2-3.0.1, tag: refs/tags/project2-3.0.0)
  Author: John Tipper <john.tipper@example.com>
  Date:   Tue Jan 28 22:57:33 2020 +0000
  
      commit submodule project2
  
  commit 540259aea51bea5b95f483ad67d0cc05be44f4da (tag: refs/tags/project1-2.0.0)
  Author: John Tipper <john.tipper@example.com>
  Date:   Tue Jan 28 22:57:33 2020 +0000
  
      commit submodule project1
  
  commit 1d89f8ba50b5a6f0e37947ea2594272f8edb40fe (tag: refs/tags/release-1.0.0)
  Author: John Tipper <john.tipper@example.com>
  Date:   Tue Jan 28 22:57:33 2020 +0000
  
      initial commit of top level project
  
  commit 949dffd4afcafa63ef280670ab26e617aa2ffdbf
  Author: John Tipper <john.tipper@example.com>
  Date:   Tue Jan 28 22:57:33 2020 +0000
  
      initial commit
```
