### PR TITLE
Adds validation for scmVersion.nextVersion.suffix - can't be empty

### DIFF
--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/BaseIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/BaseIntegrationTest.groovy
@@ -39,4 +39,8 @@ class BaseIntegrationTest extends RepositoryBasedTest {
     BuildResult runGradle(String... arguments) {
         return gradle().withArguments(arguments).build()
     }
+
+    BuildResult runGradleAndFail(String... arguments) {
+        return gradle().withArguments(arguments).buildAndFail()
+    }
 }

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/NextVersionIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/NextVersionIntegrationTest.groovy
@@ -1,0 +1,25 @@
+package pl.allegro.tech.build.axion.release
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class NextVersionIntegrationTest extends BaseIntegrationTest {
+
+    def "should fail when passing empty nextVersion.suffix"() {
+        given:
+        buildFile(
+            """
+scmVersion {
+    nextVersion {
+        suffix = ''
+    }
+}
+"""
+        )
+
+        when:
+        def result = runGradleAndFail('currentVersion')
+
+        then:
+        result.output.contains("scmVersion.nextVersion.suffix can't be empty!")
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/NextVersionPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/NextVersionPropertiesFactory.groovy
@@ -13,6 +13,12 @@ class NextVersionPropertiesFactory {
     private static final String DEPRECATED_NEXT_VERSION_PROPERTY = "release.nextVersion"
 
     static NextVersionProperties create(Project project, NextVersionConfig config) {
+        if (config.suffix == null || config.suffix.isEmpty()) {
+            String message = "scmVersion.nextVersion.suffix can't be empty! Empty suffix will prevent axion-release from distinguishing nextVersion from regular versions";
+            project.logger.error(message)
+            throw new IllegalArgumentException(message)
+        }
+
         String nextVersion = project.hasProperty(NEXT_VERSION_PROPERTY) ? project.property(NEXT_VERSION_PROPERTY) : null
         String versionIncrementerName = project.hasProperty(NEXT_VERSION_INCREMENTER_PROPERTY) ? project.property(NEXT_VERSION_INCREMENTER_PROPERTY) : null
 


### PR DESCRIPTION
Fixes #333 