### PR TITLE
Improved handling of lightweight tags

### DIFF
--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -82,8 +82,14 @@ public class GitRepository implements ScmRepository {
                 boolean onTag = ref.getName().equals(GIT_TAG_PREFIX + tagName);
                 boolean onHead;
                 try {
-                    onHead = jgitRepository.getRepository().getRefDatabase()
-                        .peel(ref).getPeeledObjectId().getName().equals(headId);
+                    ObjectId peeledObjectId = jgitRepository.getRepository().getRefDatabase()
+                        .peel(ref).getPeeledObjectId();
+                    if (peeledObjectId != null) {
+                        onHead = peeledObjectId.getName().equals(headId);
+                    } else {
+                        onHead = ref.getName().equals(headId);
+                        logger.debug("Using lightweight (not annotated) tag " + ref.getName() + ".");
+                    }
                 } catch (IOException e) {
                     throw new ScmException(e);
                 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
@@ -49,6 +49,11 @@ class GitProjectBuilder {
         return this
     }
 
+    GitProjectBuilder withLightweightTag(String name) {
+        rawRepository.tag.add(name: name, annotate: false)
+        return this
+    }
+
     GitProjectBuilder usingProperties(ScmProperties scmProperties) {
         this.scmProperties = scmProperties
         return this

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -51,6 +51,24 @@ class GitRepositoryTest extends Specification {
         thrown(ScmRepositoryUnavailableException)
     }
 
+    def "should not peel lightweight tags"() {
+        given:
+        File lightweightTagRepositoryDir = File.createTempDir('axion-release', 'tmp')
+        Map repositories = GitProjectBuilder.gitProject(lightweightTagRepositoryDir)
+            .withInitialCommit()
+            .withLightweightTag('release-1')
+            .build()
+
+        GitRepository lightweightTagRepository = repositories[GitRepository] as GitRepository
+
+        when:
+        lightweightTagRepository.tag('release-2')
+        TagsOnCommit tags = lightweightTagRepository.latestTags(~/^release.*/)
+
+        then:
+        tags.tags == ['release-1', 'release-2']
+    }
+
     def "should create new tag on current commit"() {
         when:
         repository.tag('release-1')


### PR DESCRIPTION
Hi @adamdubiel
When peeling a non-annotated, i.e. lightweight tag, object ID can be `null`, according to [jgit docs](https://download.eclipse.org/jgit/site/5.8.1.202007141445-r/apidocs/org/eclipse/jgit/lib/Ref.html#getPeeledObjectId--). This patch compares ref to `HEAD` directly for such tags.
Let me know what you think!