### PR TITLE
Attempt to fix GStringImpl error after upgrading to 1.12.0

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedReleaseCommitMessageCreator.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedReleaseCommitMessageCreator.groovy
@@ -5,7 +5,7 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 enum PredefinedReleaseCommitMessageCreator {
 
     DEFAULT('default', { String version, ScmPosition position ->
-        return "release version: $version"
+        return "release version: $version".toString()
     });
 
     private final String type

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreator.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreator.groovy
@@ -10,7 +10,7 @@ enum PredefinedVersionCreator {
 
     VERSION_WITH_BRANCH('versionWithBranch', { String versionFromTag, ScmPosition position ->
         if (position.branch != 'master' && position.branch != 'HEAD') {
-            return "$versionFromTag-$position.branch"
+            return "$versionFromTag-$position.branch".toString()
         }
         return versionFromTag
     })

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/SnapshotDependenciesChecker.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/SnapshotDependenciesChecker.groovy
@@ -22,6 +22,6 @@ class SnapshotDependenciesChecker {
     }
 
     String toFullVersion(it) {
-        "${it.group}:${it.name}:${it.version}"
+        "${it.group}:${it.name}:${it.version}".toString()
     }
 }


### PR DESCRIPTION
Fix #348 by returning java.lang.String instead of GStringImpl by simply calling .toString() on Groovy templated string.