### PR TITLE
change the multi-module doc to what works

### DIFF
--- a/docs/configuration/basic_usage.md
+++ b/docs/configuration/basic_usage.md
@@ -72,8 +72,10 @@ scmVersion {
     // ...
 }
 
-allprojects {
-    project.version = scmVersion.version
+project.version = scmVersion.version
+subprojects {
+  project.version = parent.project.version
+  // ...
 }
 ```
 


### PR DESCRIPTION
The mutli-module docs didn't seem to work for me so I looked at the integration tests and saw that it is setting `project.version` on the parent not in the `allprojects` block.