### PR TITLE
Almost all Groovy closures replaced with Java SMA

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarker.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarker.groovy
@@ -30,8 +30,8 @@ class NextVersionMarker {
             logger.info("Next Version not specified. Creating next version with default incrementer: $nextVersion")
         }
 
-        String tagName = tagRules.serialize(tagRules, nextVersion.toString())
-        String nextVersionTag = nextVersionRules.serializer(nextVersionRules, tagName)
+        String tagName = tagRules.serialize.apply(tagRules, nextVersion.toString())
+        String nextVersionTag = nextVersionRules.serializer.apply(nextVersionRules, tagName)
 
         logger.quiet("Creating next version marker tag: $nextVersionTag")
         repositoryService.tag(nextVersionTag)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/HooksConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/hooks/HooksConfig.groovy
@@ -1,40 +1,48 @@
 package pl.allegro.tech.build.axion.release.domain.hooks
 
+import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHookFactory.CustomAction
+
 class HooksConfig {
-    
+
     List<ReleaseHookAction> preReleaseHooks = []
-    
+
     List<ReleaseHookAction> postReleaseHooks = []
-    
+
     void pre(Closure c) {
-        preReleaseHooks.add(PredefinedReleaseHookAction.DEFAULT.factory.create(c))
+        preReleaseHooks.add(PredefinedReleaseHookAction.DEFAULT.factory.create(safeCastToCustomAction(c)))
     }
 
     void pre(String type) {
         preReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create())
     }
-    
+
     void pre(String type, Map arguments) {
         preReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create(arguments))
     }
 
-    void pre(String type, Closure customAction) {
-        preReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create(customAction))
+    void pre(String type, Closure c) {
+        preReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create(safeCastToCustomAction(c)))
     }
 
     void post(String type) {
         postReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create())
     }
-    
+
     void post(Closure c) {
-        postReleaseHooks.add(PredefinedReleaseHookAction.DEFAULT.factory.create(c))
+        postReleaseHooks.add(PredefinedReleaseHookAction.DEFAULT.factory.create(safeCastToCustomAction(c)))
     }
 
     void post(String type, Map arguments) {
         postReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create(arguments))
     }
-    
+
     void post(String type, Closure c) {
-        postReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create(c))
+        postReleaseHooks.add(PredefinedReleaseHookAction.factoryFor(type).create(safeCastToCustomAction(c)))
+    }
+
+    private static CustomAction safeCastToCustomAction(Closure closure) {
+        return closure.parameterTypes.length == 1 && closure.parameterTypes[0] == HookContext.class
+            ? closure
+            : { HookContext hookContext -> closure(hookContext.currentVersion, hookContext.position)}
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
@@ -29,7 +29,7 @@ public class Releaser {
         Version version = versionContext.getVersion();
 
         if (versionContext.isSnapshot()) {
-            String tagName = properties.getTag().getSerialize().call(properties.getTag(), version.toString());
+            String tagName = properties.getTag().getSerialize().apply(properties.getTag(), version.toString());
 
             hooksRunner.runPreReleaseHooks(properties.getHooks(), properties, versionContext, version);
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionFactory.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionFactory.java
@@ -2,12 +2,12 @@ package pl.allegro.tech.build.axion.release.domain;
 
 import com.github.zafarkhaja.semver.ParseException;
 import com.github.zafarkhaja.semver.Version;
-import org.codehaus.groovy.runtime.StringGroovyMethods;
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties;
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties;
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties;
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 
+import java.util.Optional;
 import java.util.regex.Pattern;
 
 public class VersionFactory {
@@ -32,12 +32,12 @@ public class VersionFactory {
     public Version versionFromTag(String tag) {
         String tagWithoutNextVersion = tag;
         if (Pattern.matches(".*" + nextVersionProperties.getSuffix() + "$", tag)) {
-            tagWithoutNextVersion = nextVersionProperties.getDeserializer().call(nextVersionProperties, position, tag);
+            tagWithoutNextVersion = nextVersionProperties.getDeserializer().apply(nextVersionProperties, position, tag);
         }
 
         try {
             return Version.valueOf(
-                tagProperties.getDeserialize().call(tagProperties, position, tagWithoutNextVersion)
+                tagProperties.getDeserialize().apply(tagProperties, position, tagWithoutNextVersion)
             );
         } catch (ParseException parseException) {
             throw new TagParseException(tagProperties.getPrefix(), tagWithoutNextVersion, parseException);
@@ -46,7 +46,7 @@ public class VersionFactory {
     }
 
     public Version initialVersion() {
-        return Version.valueOf(tagProperties.getInitialVersion().call(tagProperties, position));
+        return Version.valueOf(tagProperties.getInitialVersion().apply(tagProperties, position));
     }
 
     public FinalVersion createFinalVersion(ScmState scmState, Version version) {
@@ -61,14 +61,11 @@ public class VersionFactory {
         boolean proposedVersionIsAlreadySnapshot = scmState.isOnNextVersionTag() || scmState.isNoReleaseTagsFound();
         boolean incrementVersion = ((versionProperties.isForceSnapshot() || hasChanges) && !proposedVersionIsAlreadySnapshot);
 
-        Version finalVersion = version;
-        if (StringGroovyMethods.asBoolean(versionProperties.getForcedVersion())) {
-            finalVersion = Version.valueOf(versionProperties.getForcedVersion());
-        } else if (incrementVersion) {
-            finalVersion = versionProperties.getVersionIncrementer().call(new VersionIncrementerContext(
-                version, position
-            ));
-        }
+        Version finalVersion = Optional.ofNullable(versionProperties.getForcedVersion())
+            .filter(s -> !s.isEmpty()).map(Version::valueOf)
+            .orElseGet(() -> incrementVersion
+                ? versionProperties.getVersionIncrementer().apply(new VersionIncrementerContext(version, position))
+                : version);
 
         return new FinalVersion(
             finalVersion,

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
@@ -23,7 +23,7 @@ public class VersionService {
 
     public DecoratedVersion currentDecoratedVersion(VersionProperties versionProperties, TagProperties tagRules, NextVersionProperties nextVersionRules) {
         VersionContext versionContext = versionResolver.resolveVersion(versionProperties, tagRules, nextVersionRules);
-        String version = versionProperties.getVersionCreator().call(versionContext.getVersion().toString(), versionContext.getPosition());
+        String version = versionProperties.getVersionCreator().apply(versionContext.getVersion().toString(), versionContext.getPosition());
 
         if (versionProperties.isSanitizeVersion()) {
             version = sanitizer.sanitize(version);

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/CommitHookAction.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/CommitHookAction.java
@@ -1,30 +1,22 @@
 package pl.allegro.tech.build.axion.release.domain.hooks;
 
-import groovy.lang.Closure;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
-
-import java.util.function.BiFunction;
+import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHookFactory.CustomAction;
 
 public class CommitHookAction implements ReleaseHookAction {
 
-    private final Closure customAction;
+    private final CustomAction customAction;
 
-    public CommitHookAction(Closure customAction) {
+    public CommitHookAction(CustomAction customAction) {
         this.customAction = customAction;
     }
 
     public CommitHookAction() {
-        this(new Closure<String>(null) {
-            @Override
-            public String call(Object... args) {
-                return "Release version: " + args[0];
-            }
-        });
+        this((hookContext) -> "Release version: " + hookContext.getCurrentVersion());
     }
 
     @Override
     public void act(HookContext hookContext) {
-        String message = (customAction.call(hookContext.getCurrentVersion(), hookContext.getPosition())).toString();
+        String message = (customAction.apply(hookContext)).toString();
         hookContext.commit(hookContext.getPatternsToCommit(), message);
     }
 
@@ -35,7 +27,7 @@ public class CommitHookAction implements ReleaseHookAction {
         }
 
         @Override
-        public ReleaseHookAction create(Closure customAction) {
+        public ReleaseHookAction create(CustomAction customAction) {
             return new CommitHookAction(customAction);
         }
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/DefaultReleaseHookFactory.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/DefaultReleaseHookFactory.java
@@ -1,10 +1,6 @@
 package pl.allegro.tech.build.axion.release.domain.hooks;
 
-import groovy.lang.Closure;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
-
 import java.util.Map;
-import java.util.function.BiFunction;
 
 public class DefaultReleaseHookFactory implements ReleaseHookFactory {
 
@@ -19,7 +15,7 @@ public class DefaultReleaseHookFactory implements ReleaseHookFactory {
     }
 
     @Override
-    public ReleaseHookAction create(Closure customAction) {
+    public ReleaseHookAction create(CustomAction customAction) {
         throw new UnsupportedOperationException(this.getClass() + " does not construct release hooks from Closure");
     }
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHookFactory.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHookFactory.java
@@ -1,16 +1,16 @@
 package pl.allegro.tech.build.axion.release.domain.hooks;
 
-import groovy.lang.Closure;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
-
 import java.util.Map;
-import java.util.function.BiFunction;
 
 public interface ReleaseHookFactory {
+
+    interface CustomAction {
+        Object apply(HookContext hookContext);
+    }
 
     ReleaseHookAction create();
 
     ReleaseHookAction create(Map<String, Object> arguments);
 
-    ReleaseHookAction create(Closure customAction);
+    ReleaseHookAction create(CustomAction customAction);
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/SimpleReleaseHookAction.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/SimpleReleaseHookAction.java
@@ -1,23 +1,23 @@
 package pl.allegro.tech.build.axion.release.domain.hooks;
 
-import groovy.lang.Closure;
+import pl.allegro.tech.build.axion.release.domain.hooks.ReleaseHookFactory.CustomAction;
 
 public class SimpleReleaseHookAction implements ReleaseHookAction {
 
-    private final Closure customAction;
+    private final CustomAction customAction;
 
-    public SimpleReleaseHookAction(Closure customAction) {
+    public SimpleReleaseHookAction(CustomAction customAction) {
         this.customAction = customAction;
     }
 
     @Override
     public void act(HookContext hookContext) {
-        customAction.call(hookContext);
+        customAction.apply(hookContext);
     }
 
     public final static class Factory extends DefaultReleaseHookFactory {
         @Override
-        public ReleaseHookAction create(Closure customAction) {
+        public ReleaseHookAction create(CustomAction customAction) {
             return new SimpleReleaseHookAction(customAction);
         }
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/NextVersionProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/NextVersionProperties.java
@@ -1,23 +1,31 @@
 package pl.allegro.tech.build.axion.release.domain.properties;
 
-import groovy.lang.Closure;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 
 public class NextVersionProperties {
+
+    public interface Serializer {
+        String apply(NextVersionProperties nextVersionProperties, String version);
+    }
+
+    public interface Deserializer {
+        String apply(NextVersionProperties nextVersionProperties, ScmPosition position, String tag);
+    }
 
     private final String nextVersion;
     private final String suffix;
     private final String separator;
     private final String versionIncrementer;
-    private final Closure<String> serializer;
-    private final Closure<String> deserializer;
+    private final Serializer serializer;
+    private final Deserializer deserializer;
 
     public NextVersionProperties(
         String nextVersion,
         String suffix,
         String separator,
         String versionIncrementer,
-        Closure<String> serializer,
-        Closure<String> deserializer
+        Serializer serializer,
+        Deserializer deserializer
     ) {
         this.nextVersion = nextVersion;
         this.suffix = suffix;
@@ -43,11 +51,11 @@ public class NextVersionProperties {
         return versionIncrementer;
     }
 
-    public final Closure<String> getSerializer() {
+    public final Serializer getSerializer() {
         return serializer;
     }
 
-    public final Closure<String> getDeserializer() {
+    public final Deserializer getDeserializer() {
         return deserializer;
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/TagProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/TagProperties.java
@@ -1,21 +1,33 @@
 package pl.allegro.tech.build.axion.release.domain.properties;
 
-import groovy.lang.Closure;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 
 public class TagProperties {
 
+    public interface Serializer {
+        String apply(TagProperties tagProperties, String version);
+    }
+
+    public interface Deserializer {
+        String apply(TagProperties tagProperties, ScmPosition position, String tag);
+    }
+
+    public interface InitialVersionSupplier {
+        String apply(TagProperties tagProperties, ScmPosition position);
+    }
+
     private final String prefix;
     private final String versionSeparator;
-    private final Closure<String> serialize;
-    private final Closure<String> deserialize;
-    private final Closure<String> initialVersion;
+    private final Serializer serialize;
+    private final Deserializer deserialize;
+    private final InitialVersionSupplier initialVersion;
 
     public TagProperties(
         String prefix,
         String versionSeparator,
-        Closure<String> serialize,
-        Closure<String> deserialize,
-        Closure<String> initialVersion
+        Serializer serialize,
+        Deserializer deserialize,
+        InitialVersionSupplier initialVersion
     ) {
         this.prefix = prefix;
         this.versionSeparator = versionSeparator;
@@ -32,15 +44,15 @@ public class TagProperties {
         return versionSeparator;
     }
 
-    public final Closure<String> getSerialize() {
+    public final Serializer getSerialize() {
         return serialize;
     }
 
-    public final Closure<String> getDeserialize() {
+    public final Deserializer getDeserialize() {
         return deserialize;
     }
 
-    public final Closure<String> getInitialVersion() {
+    public final InitialVersionSupplier getInitialVersion() {
         return initialVersion;
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.java
@@ -1,15 +1,24 @@
 package pl.allegro.tech.build.axion.release.domain.properties;
 
 import com.github.zafarkhaja.semver.Version;
-import groovy.lang.Closure;
+import pl.allegro.tech.build.axion.release.domain.VersionIncrementerContext;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 
 public class VersionProperties {
+
+    public interface Creator {
+        String apply(String versionFromTag, ScmPosition position);
+    }
+
+    public interface Incrementer {
+        Version apply(VersionIncrementerContext versionIncrementerContext);
+    }
 
     private final String forcedVersion;
     private final boolean forceSnapshot;
     private final boolean ignoreUncommittedChanges;
-    private final Closure<String> versionCreator;
-    private final Closure<Version> versionIncrementer;
+    private final Creator versionCreator;
+    private final Incrementer versionIncrementer;
     private final boolean sanitizeVersion;
     private final boolean useHighestVersion;
     private final MonorepoProperties monorepoProperties;
@@ -18,8 +27,8 @@ public class VersionProperties {
         String forcedVersion,
         boolean forceSnapshot,
         boolean ignoreUncommittedChanges,
-        Closure<String> versionCreator,
-        Closure<Version> versionIncrementer,
+        Creator versionCreator,
+        Incrementer versionIncrementer,
         boolean sanitizeVersion,
         boolean useHighestVersion,
         MonorepoProperties monorepoProperties
@@ -50,11 +59,11 @@ public class VersionProperties {
         return ignoreUncommittedChanges;
     }
 
-    public final Closure<String> getVersionCreator() {
+    public final Creator getVersionCreator() {
         return versionCreator;
     }
 
-    public final Closure<Version> getVersionIncrementer() {
+    public final Incrementer getVersionIncrementer() {
         return versionIncrementer;
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/CommitHookActionTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/CommitHookActionTest.groovy
@@ -4,22 +4,22 @@ import pl.allegro.tech.build.axion.release.RepositoryBasedTest
 import pl.allegro.tech.build.axion.release.domain.scm.ScmService
 
 class CommitHookActionTest extends RepositoryBasedTest {
-    
+
     ScmService scmService
-    
+
     def setup() {
         scmService = context.scmService()
     }
-    
+
     def "should commit files matching patterns with given message"() {
         given:
-        CommitHookAction hook = new CommitHookAction({v, p -> "test of version $v"})
+        CommitHookAction hook = new CommitHookAction({ HookContext hookContext -> "test of version ${hookContext.currentVersion}" })
         HookContext context = new HookContextBuilder(scmService: scmService, previousVersion: '1.0.0', currentVersion: '2.0.0').build()
         context.addCommitPattern('*')
-        
+
         when:
         hook.act(context)
-        
+
         then:
         repository.lastLogMessages(1) == ['test of version 2.0.0']
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/HooksPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/HooksPropertiesBuilder.groovy
@@ -22,7 +22,9 @@ class HooksPropertiesBuilder {
     }
 
     HooksPropertiesBuilder withCommitHook() {
-        pre.add(PredefinedReleaseHookAction.factoryFor('commit').create(PredefinedReleaseCommitMessageCreator.DEFAULT.commitMessageCreator))
+        pre.add(PredefinedReleaseHookAction.factoryFor('commit').create(
+            { hookContext -> PredefinedReleaseCommitMessageCreator.DEFAULT.commitMessageCreator(hookContext.currentVersion, hookContext.position) }
+        ))
         return this
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/NextVersionPropertiesFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/NextVersionPropertiesFactoryTest.groovy
@@ -3,6 +3,7 @@ package pl.allegro.tech.build.axion.release.infrastructure.config
 import org.gradle.api.Project
 import pl.allegro.tech.build.axion.release.domain.NextVersionConfig
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import spock.lang.Specification
 
 import static org.gradle.testfixtures.ProjectBuilder.builder
@@ -21,8 +22,8 @@ class NextVersionPropertiesFactoryTest extends Specification {
         given:
         project.extensions.extraProperties.set('release.version', '1.0.0')
 
-        config.serializer = {'serialize'}
-        config.deserializer = {'deserialize'}
+        config.serializer = { config, version -> 'serialize'}
+        config.deserializer = { config, position, tagName -> 'deserialize'}
         config.suffix = 'something'
         config.separator = '='
 
@@ -30,8 +31,8 @@ class NextVersionPropertiesFactoryTest extends Specification {
         NextVersionProperties properties = NextVersionPropertiesFactory.create(project, config)
 
         then:
-        properties.serializer() == 'serialize'
-        properties.deserializer() == 'deserialize'
+        properties.serializer.apply(properties, "any") == 'serialize'
+        properties.deserializer.apply(properties, new ScmPosition("shortsha", "longsha", "master"), "any") == 'deserialize'
         properties.suffix == 'something'
         properties.separator == '='
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactoryTest.groovy
@@ -30,7 +30,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
 
         then:
-        rules.versionIncrementer() == new Version.Builder('1.2.3').build()
+        rules.versionIncrementer.apply(null) == new Version.Builder('1.2.3').build()
         rules.sanitizeVersion == versionConfig.sanitizeVersion
     }
 
@@ -123,7 +123,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
 
         then:
-        rules.versionCreator(null, null) == 'default'
+        rules.versionCreator.apply(null, null) == 'default'
     }
 
     def "should pick version creator suitable for current branch if defined in per branch creators"() {
@@ -137,7 +137,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
 
         then:
-        rules.versionCreator(null, null) == 'someBranch'
+        rules.versionCreator.apply(null, null) == 'someBranch'
     }
 
     def "should use predefined version creator when supplied with String in per branch creators"() {
@@ -151,7 +151,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
 
         then:
-        rules.versionCreator('1.0.0', scmPosition('someBranch')) == '1.0.0-someBranch'
+        rules.versionCreator.apply('1.0.0', scmPosition('someBranch')) == '1.0.0-someBranch'
     }
 
 
@@ -167,7 +167,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
 
         then:
-        rules.versionCreator('1.0.0', scmPosition('someBranch')) == '1.0.0'
+        rules.versionCreator.apply('1.0.0', scmPosition('someBranch')) == '1.0.0'
     }
 
     def "should pick default version incrementer if none branch incrementers match"() {
@@ -181,7 +181,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'master')
 
         then:
-        rules.versionIncrementer(
+        rules.versionIncrementer.apply(
             new VersionIncrementerContext(Version.forIntegers(1), scmPosition().build())
         ) == Version.forIntegers(1)
     }
@@ -197,7 +197,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
 
         then:
-        rules.versionIncrementer(
+        rules.versionIncrementer.apply(
             new VersionIncrementerContext(Version.forIntegers(1), scmPosition().build())
         ) == Version.forIntegers(2)
     }
@@ -213,7 +213,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
 
         then:
-        rules.versionIncrementer(
+        rules.versionIncrementer.apply(
             new VersionIncrementerContext(Version.forIntegers(1), scmPosition().build())
         ) == Version.forIntegers(2)
     }
@@ -229,7 +229,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
 
         then:
-        rules.versionIncrementer(
+        rules.versionIncrementer.apply(
             new VersionIncrementerContext(Version.forIntegers(1), scmPosition('someBranch'))
         ) == Version.forIntegers(1, 1)
     }
@@ -243,7 +243,7 @@ class VersionPropertiesFactoryTest extends Specification {
         VersionProperties rules = VersionPropertiesFactory.create(project, versionConfig, 'someBranch')
 
         then:
-        rules.versionIncrementer(
+        rules.versionIncrementer.apply(
             new VersionIncrementerContext(Version.forIntegers(1), scmPosition().build())
         ) == Version.forIntegers(2)
 


### PR DESCRIPTION
I have replaced almost all Groovy closures with Java single abstract method interfaces in the part of the code written in Java.

I think this PR might be the next step in #315 .

There was a problem that different hooks used the same interface for creation `ReleaseHookFactory::create(Closure c)`, but the closure reqiured differen signatures, either a `HookContect` or a pair of current version `String` and `ScmPosition`. I have added `HooksConfig::safeCastToCustomAction` to solve this. Now you can use a `HookContext` for all hooks, but backward compatibility is preserved. 

 I have also removed some other minor Groovy dependencies. The only place that still has Groovy runtime dependency is `FileUpdateHookAction`. I think I can handle this too, if you find this patch useful.

