### PR TITLE
Exposed getPreviousVersion() API

### DIFF
--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/ScmVersionExposedApiIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/ScmVersionExposedApiIntegrationTest.groovy
@@ -5,11 +5,12 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 
 class ScmVersionExposedApiIntegrationTest extends BaseIntegrationTest {
 
-    def "should return final version scmVersion.version"() {
+    def "should return version information"() {
         given:
         buildFile("""
         task outputDecorated { doLast {
             println "Version: \${scmVersion.version}"
+            println "Previous: \${scmVersion.previousVersion}" //'previousVersion' property smoke test
         } }
         """)
 
@@ -18,6 +19,7 @@ class ScmVersionExposedApiIntegrationTest extends BaseIntegrationTest {
 
         then:
         result.output.contains('Version: 0.1.0-SNAPSHOT')
+        result.output.contains('Previous: 0.1.0')
         result.task(":outputDecorated").outcome == TaskOutcome.SUCCESS
     }
 
@@ -40,7 +42,7 @@ class ScmVersionExposedApiIntegrationTest extends BaseIntegrationTest {
     def "should return scm position from which version was read at scmVersion.scmPosition"() {
         given:
         buildFile("""
-        task outputPosition { doLast { 
+        task outputPosition { doLast {
             println "Revision: \${scmVersion.scmPosition.revision}"
             println "Short revision: \${scmVersion.scmPosition.shortRevision}"
             println "Branch: \${scmVersion.scmPosition.branch}"

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -152,7 +152,7 @@ class VersionConfig {
         return resolvedVersion.decoratedVersion
     }
 
-    @Nested
+    @Input
     String getPreviousVersion() {
         ensureVersionExists()
         return resolvedVersion.previousVersion

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -152,6 +152,12 @@ class VersionConfig {
         return resolvedVersion.decoratedVersion
     }
 
+    @Nested
+    String getPreviousVersion() {
+        ensureVersionExists()
+        return resolvedVersion.previousVersion
+    }
+
     @Input
     String getUndecoratedVersion() {
         ensureVersionExists()

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
@@ -38,7 +38,8 @@ public class VersionService {
         }
 
 
-        return new DecoratedVersion(versionContext.getVersion().toString(), finalVersion, versionContext.getPosition());
+        return new DecoratedVersion(versionContext.getVersion().toString(), finalVersion, versionContext.getPosition(),
+            versionContext.getPreviousVersion().toString());
     }
 
     public static class DecoratedVersion {
@@ -46,11 +47,14 @@ public class VersionService {
         private final String undecoratedVersion;
         private final String decoratedVersion;
         private final ScmPosition position;
+        private final String previousVersion;
 
-        public DecoratedVersion(String undecoratedVersion, String decoratedVersion, ScmPosition position) {
+        public DecoratedVersion(String undecoratedVersion, String decoratedVersion, ScmPosition position,
+                                String previousVersion) {
             this.undecoratedVersion = undecoratedVersion;
             this.decoratedVersion = decoratedVersion;
             this.position = position;
+            this.previousVersion = previousVersion;
         }
 
         @Input
@@ -66,6 +70,11 @@ public class VersionService {
         @Nested
         public final ScmPosition getPosition() {
             return position;
+        }
+
+        @Nested
+        public final String getPreviousVersion() {
+            return previousVersion;
         }
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
@@ -72,7 +72,7 @@ public class VersionService {
             return position;
         }
 
-        @Nested
+        @Input
         public final String getPreviousVersion() {
             return previousVersion;
         }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
@@ -104,13 +104,13 @@ class VersionServiceTest extends Specification {
         version.snapshot
     }
 
-    def "should return both decorated and undecorated version"() {
+    def "should return version information"() {
         given:
         VersionProperties properties = versionProperties().withVersionCreator({ v, t -> v }).build()
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf("1.0.1"),
             true,
-            Version.valueOf("1.0.1"),
+            Version.valueOf("1.0.0"),
             new ScmPosition('', '', 'master')
         )
 
@@ -120,6 +120,7 @@ class VersionServiceTest extends Specification {
         then:
         version.undecoratedVersion == '1.0.1'
         version.decoratedVersion == '1.0.1-SNAPSHOT'
+        version.previousVersion == '1.0.0'
     }
 
     def "should sanitize version if flag is set to true"() {


### PR DESCRIPTION
Hey team! Would this new API make sense?

It is useful to expose the previous version for automated generation of the changelog. This has been requested before in #138. Sample usage of this new property here: https://github.com/mockito/mockito-kotlin/pull/421

Thoughts?