### PR TITLE
Exposed actual previous tag

### DIFF
--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/ScmVersionExposedApiIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/ScmVersionExposedApiIntegrationTest.groovy
@@ -11,6 +11,7 @@ class ScmVersionExposedApiIntegrationTest extends BaseIntegrationTest {
         task outputDecorated { doLast {
             println "Version: \${scmVersion.version}"
             println "Previous: \${scmVersion.previousVersion}" //'previousVersion' property smoke test
+            println "Previous tag: \${scmVersion.previousTag}" //'previousVersion' property smoke test
         } }
         """)
 
@@ -20,6 +21,7 @@ class ScmVersionExposedApiIntegrationTest extends BaseIntegrationTest {
         then:
         result.output.contains('Version: 0.1.0-SNAPSHOT')
         result.output.contains('Previous: 0.1.0')
+        result.output.contains('Previous tag: null')
         result.task(":outputDecorated").outcome == TaskOutcome.SUCCESS
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -3,8 +3,8 @@ package pl.allegro.tech.build.axion.release.domain
 import org.gradle.api.Project
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
+import org.gradle.api.tasks.Optional
 import pl.allegro.tech.build.axion.release.ReleasePlugin
-import pl.allegro.tech.build.axion.release.TagPrefixConf
 import pl.allegro.tech.build.axion.release.domain.hooks.HooksConfig
 import pl.allegro.tech.build.axion.release.domain.properties.Properties
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
@@ -155,10 +155,27 @@ class VersionConfig {
         return resolvedVersion.decoratedVersion
     }
 
+    /**
+     * Previous version in the context of the 'next version marker' mechanism.
+     * Caveat: if 'next version marker' tag was not found then {@link #getPreviousVersion()} will be equal to {@link #getVersion()}
+     * and potentially <em>different</em> than {@link #getPreviousTag()}.
+     */
     @Input
+    @Optional
     String getPreviousVersion() {
         ensureVersionExists()
         return resolvedVersion.previousVersion
+    }
+
+    /**
+     * Previous release tag. Simplified example assuming a typical configuration:
+     * given tags are 'v1.2.0', 'v1.1.0', 'v1.0.0', and we checked out 'v1.2.0', previous tag will be 'v1.1.0'.
+     */
+    @Input
+    @Optional
+    String getPreviousTag() {
+        ensureVersionExists()
+        return resolvedVersion.previousTag
     }
 
     @Input

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionContext.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionContext.java
@@ -6,12 +6,14 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 public class VersionContext {
 
     private final Version version;
+    private final String previousTag;
     private final boolean snapshot;
     private final Version previousVersion;
     private final ScmPosition position;
 
-    public VersionContext(Version version, boolean snapshot, Version previousVersion, ScmPosition position) {
+    public VersionContext(Version version, String previousTag, boolean snapshot, Version previousVersion, ScmPosition position) {
         this.version = version;
+        this.previousTag = previousTag;
         this.snapshot = snapshot;
         this.previousVersion = previousVersion;
         this.position = position;
@@ -31,6 +33,10 @@ public class VersionContext {
 
     public final ScmPosition getPosition() {
         return position;
+    }
+
+    public String getPreviousTag() {
+        return previousTag;
     }
 
     @Override

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
@@ -2,6 +2,7 @@ package pl.allegro.tech.build.axion.release.domain;
 
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Nested;
+import org.gradle.api.tasks.Optional;
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties;
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties;
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties;
@@ -37,9 +38,8 @@ public class VersionService {
             finalVersion = finalVersion + "-" + SNAPSHOT;
         }
 
-
         return new DecoratedVersion(versionContext.getVersion().toString(), finalVersion, versionContext.getPosition(),
-            versionContext.getPreviousVersion().toString());
+            versionContext.getPreviousVersion().toString(), versionContext.getPreviousTag());
     }
 
     public static class DecoratedVersion {
@@ -48,13 +48,15 @@ public class VersionService {
         private final String decoratedVersion;
         private final ScmPosition position;
         private final String previousVersion;
+        private final String previousTag;
 
         public DecoratedVersion(String undecoratedVersion, String decoratedVersion, ScmPosition position,
-                                String previousVersion) {
+                                String previousVersion, String previousTag) {
             this.undecoratedVersion = undecoratedVersion;
             this.decoratedVersion = decoratedVersion;
             this.position = position;
             this.previousVersion = previousVersion;
+            this.previousTag = previousTag;
         }
 
         @Input
@@ -73,8 +75,15 @@ public class VersionService {
         }
 
         @Input
+        @Optional
         public final String getPreviousVersion() {
             return previousVersion;
+        }
+
+        @Input
+        @Optional
+        public final String getPreviousTag() {
+            return previousTag;
         }
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
@@ -18,9 +18,13 @@ public class TaggedCommits {
         return new TaggedCommits(latestTagPosition, taggedCommits);
     }
 
-    public static TaggedCommits fromLatestCommit(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition) {
-        TagsOnCommit latestTags = repository.latestTags(tagPattern);
-        return new TaggedCommits(latestTagPosition, Arrays.asList(latestTags));
+    public static TaggedCommits fromLatestCommit(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition, List<String> previousTag) {
+        List<TagsOnCommit> tagsOnCommits = repository.taggedCommits(tagPattern);
+        TagsOnCommit latest = tagsOnCommits.isEmpty() ? TagsOnCommit.empty() : tagsOnCommits.iterator().next();
+        if (tagsOnCommits.size() > 1) {
+            previousTag.add(tagsOnCommits.get(1).getTags().iterator().next());
+        }
+        return new TaggedCommits(latestTagPosition, Arrays.asList(latest));
     }
 
     public static TaggedCommits fromAllCommits(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition) {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
@@ -372,6 +372,7 @@ class VersionResolverTest extends RepositoryBasedTest {
         then:
         version.previousVersion.toString() == '1.2.0'
         version.version.toString() == '1.2.0'
+        version.previousTag == 'v1.5.0'
         !version.snapshot
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
@@ -37,6 +37,7 @@ class VersionServiceTest extends Specification {
         VersionProperties properties = versionProperties().build()
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf('1.0.0'),
+            null,
             false,
             Version.valueOf('1.0.0'),
             new ScmPosition('', '', 'master')
@@ -55,6 +56,7 @@ class VersionServiceTest extends Specification {
         VersionProperties properties = versionProperties().forceSnapshot().build()
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf('1.0.1'),
+            null,
             true,
             Version.valueOf('1.0.1'),
             new ScmPosition('', '', 'master')
@@ -73,6 +75,7 @@ class VersionServiceTest extends Specification {
         VersionProperties properties = versionProperties().build()
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf("1.0.1"),
+            null,
             true,
             Version.valueOf("1.0.1"),
             new ScmPosition('', '', 'master')
@@ -91,6 +94,7 @@ class VersionServiceTest extends Specification {
         VersionProperties properties = versionProperties().dontIgnoreUncommittedChanges().build()
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf("1.0.1"),
+            null,
             true,
             Version.valueOf("1.0.1"),
             new ScmPosition('', '', 'master')
@@ -109,6 +113,7 @@ class VersionServiceTest extends Specification {
         VersionProperties properties = versionProperties().withVersionCreator({ v, t -> v }).build()
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf("1.0.1"),
+            "v1.0.0",
             true,
             Version.valueOf("1.0.0"),
             new ScmPosition('', '', 'master')
@@ -121,6 +126,7 @@ class VersionServiceTest extends Specification {
         version.undecoratedVersion == '1.0.1'
         version.decoratedVersion == '1.0.1-SNAPSHOT'
         version.previousVersion == '1.0.0'
+        version.previousTag == 'v1.0.0'
     }
 
     def "should sanitize version if flag is set to true"() {
@@ -129,6 +135,7 @@ class VersionServiceTest extends Specification {
 
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf("1.0.1"),
+            null,
             true,
             Version.valueOf("1.0.1"),
             new ScmPosition('', '', 'master')
@@ -150,6 +157,7 @@ class VersionServiceTest extends Specification {
 
         resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
             Version.valueOf("1.0.1"),
+            null,
             true,
             Version.valueOf("1.0.1"),
             new ScmPosition('', '', 'master')

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunnerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/hooks/ReleaseHooksRunnerTest.groovy
@@ -3,8 +3,6 @@ package pl.allegro.tech.build.axion.release.domain.hooks
 import com.github.zafarkhaja.semver.Version
 import pl.allegro.tech.build.axion.release.domain.VersionContext
 import pl.allegro.tech.build.axion.release.domain.properties.HooksProperties
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPositionBuilder
 import spock.lang.Specification
 
 import static pl.allegro.tech.build.axion.release.domain.scm.ScmPositionBuilder.scmPosition
@@ -15,6 +13,7 @@ class ReleaseHooksRunnerTest extends Specification {
 
     private VersionContext version = new VersionContext(
             new Version.Builder().setNormalVersion('2.0.0-SNAPSHOT').build(),
+            null,
             true,
             new Version.Builder().setNormalVersion('1.0.0').build(),
             scmPosition('master')


### PR DESCRIPTION
Hey, I'm trying to improve the `previousVersion` behavior (#395) so that axion plugin better integrates with plugins that automatically generate release notes. It turns out that it's quite tricky (for me ;) given various features of the axion plugin.

This PR is a simplest hack that *mostly* works. Can someone on the team provide guidance?