### PR TITLE
feat: enable snapshot customization

### DIFF
--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -57,6 +57,9 @@ All `axion-release-plugin` configuration options:
             'feature/.*': 'default'
         ]
 
+        // doc: Version / Snapshot
+        snapshotCreator { version, position -> ... } // customize 'snapshot' suffix for version not on tag
+
         // doc: Version / Incrementing
         versionIncrementer {context, config -> ...} // closure that increments a version from the raw version, current position in scm and config
         versionIncrementer 'incrementPatch' // use one of predefined version incrementing rules

--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -6,11 +6,11 @@ can be split in six phases:
 
 -   reading - read tags from repository
 -   parsing - extracting version from tag (serializing version to tag)
--   incrementing - when not on tag, version patch (leas significant)
+-   incrementing - when not on tag, version patch (least significant)
     number is incremented
 -   decorating - adding additional transformations to create final
     version
--   appending snapshot - when not on tag, SNAPSHOT suffix is appended
+-   appending snapshot - when not on tag, -SNAPSHOT suffix is appended (can be customized)
 -   sanitization - making sure there are no unwanted characters in
     version
 
@@ -330,6 +330,24 @@ Custom version creators can be implemented by creating closure:
 
 -   version - string version resolved by previous steps
 -   position - [ScmPosition](https://github.com/allegro/axion-release-plugin/blob/master/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPosition.groovy) object
+
+### Snapshot
+
+By default, when not on tag, `-SNAPSHOT` suffix is appended
+
+It can be customized by
+
+    scmVersion {
+       snapshotCreator: { version, position -> ...}
+    }
+
+Snapshot creator can be implemented by creating closure:
+
+    {version, position -> ...}
+
+-   version - string version resolved by previous steps
+-   position - [ScmPosition](https://github.com/allegro/axion-release-plugin/blob/master/src/main/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPosition.groovy) object
+
 
 ## Sanitization
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedSnapshotCreator.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedSnapshotCreator.groovy
@@ -1,0 +1,28 @@
+package pl.allegro.tech.build.axion.release.domain
+
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
+
+enum PredefinedSnapshotCreator {
+
+    SIMPLE('simple', { String version, ScmPosition position ->
+        return "-SNAPSHOT";
+    }),
+
+    private final String type
+
+    final Closure snapshotCreator
+
+    private PredefinedSnapshotCreator(String type, Closure c) {
+        this.type = type
+        this.snapshotCreator = c
+    }
+
+    static Closure snapshotCreatorFor(String type) {
+        PredefinedSnapshotCreator creator = values().find { it.type == type }
+        if (creator == null) {
+            throw new IllegalArgumentException("There is no predefined snapshot creator with $type type. " +
+                    "You can choose from: ${values().collect { it.type }}");
+        }
+        return creator.snapshotCreator
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -41,6 +41,9 @@ class VersionConfig {
     @Nested
     Closure versionCreator = PredefinedVersionCreator.SIMPLE.versionCreator
 
+    @Nested
+    Closure snapshotCreator = PredefinedSnapshotCreator.SIMPLE.snapshotCreator
+
     @Input
     Map<String, Object> branchVersionCreator = [:]
 
@@ -123,6 +126,10 @@ class VersionConfig {
 
     void versionCreator(Closure c) {
         this.versionCreator = c
+    }
+
+    void snapshotCreator(Closure c) {
+        this.snapshotCreator = c
     }
 
     void branchVersionCreator(Map<String, Object> creators) {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/VersionPropertiesFactory.groovy
@@ -40,6 +40,7 @@ class VersionPropertiesFactory {
             forceSnapshot,
             ignoreUncommittedChanges,
             findVersionCreator(project, config, currentBranch),
+            config.snapshotCreator,
             findVersionIncrementer(project, config, currentBranch),
             config.sanitizeVersion,
             useHighestVersion,

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionService.java
@@ -9,7 +9,6 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 
 public class VersionService {
 
-    public static final String SNAPSHOT = "SNAPSHOT";
     private final VersionResolver versionResolver;
     private final VersionSanitizer sanitizer;
 
@@ -34,7 +33,7 @@ public class VersionService {
 
         String finalVersion = version;
         if (versionContext.isSnapshot()) {
-            finalVersion = finalVersion + "-" + SNAPSHOT;
+            finalVersion = finalVersion + versionProperties.getSnapshotCreator().call(version,  versionContext.getPosition());
         }
 
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/VersionProperties.java
@@ -9,6 +9,7 @@ public class VersionProperties {
     private final boolean forceSnapshot;
     private final boolean ignoreUncommittedChanges;
     private final Closure<String> versionCreator;
+    private final Closure<String> snapshotCreator;
     private final Closure<Version> versionIncrementer;
     private final boolean sanitizeVersion;
     private final boolean useHighestVersion;
@@ -19,6 +20,7 @@ public class VersionProperties {
         boolean forceSnapshot,
         boolean ignoreUncommittedChanges,
         Closure<String> versionCreator,
+        Closure<String> snapshotCreator,
         Closure<Version> versionIncrementer,
         boolean sanitizeVersion,
         boolean useHighestVersion,
@@ -28,6 +30,7 @@ public class VersionProperties {
         this.forceSnapshot = forceSnapshot;
         this.ignoreUncommittedChanges = ignoreUncommittedChanges;
         this.versionCreator = versionCreator;
+        this.snapshotCreator = snapshotCreator;
         this.versionIncrementer = versionIncrementer;
         this.sanitizeVersion = sanitizeVersion;
         this.useHighestVersion = useHighestVersion;
@@ -52,6 +55,10 @@ public class VersionProperties {
 
     public final Closure<String> getVersionCreator() {
         return versionCreator;
+    }
+
+    public final Closure<String> getSnapshotCreator() {
+        return snapshotCreator;
     }
 
     public final Closure<Version> getVersionIncrementer() {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionServiceTest.groovy
@@ -161,4 +161,24 @@ class VersionServiceTest extends Specification {
         then:
         version == '1.0.1-feature/hello-SNAPSHOT'
     }
+
+    def "should allow for customizing snapshot"() {
+        given:
+        VersionProperties properties = versionProperties()
+            .withSnapshotCreator({ v, t -> return ".dirty" } )
+            .build()
+
+        resolver.resolveVersion(properties, tagProperties, nextVersionProperties) >> new VersionContext(
+            Version.valueOf("1.0.1"),
+            true,
+            Version.valueOf("1.0.1"),
+            new ScmPosition('', '', 'master')
+        )
+
+        when:
+        String version = service.currentDecoratedVersion(properties, tagProperties, nextVersionProperties).decoratedVersion
+
+        then:
+        version == '1.0.1.dirty'
+    }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/VersionPropertiesBuilder.groovy
@@ -1,5 +1,6 @@
 package pl.allegro.tech.build.axion.release.domain.properties
 
+import pl.allegro.tech.build.axion.release.domain.PredefinedSnapshotCreator
 import pl.allegro.tech.build.axion.release.domain.PredefinedVersionCreator
 import pl.allegro.tech.build.axion.release.domain.PredefinedVersionIncrementer
 
@@ -17,6 +18,8 @@ class VersionPropertiesBuilder {
 
     private Closure<String> versionCreator = PredefinedVersionCreator.SIMPLE.versionCreator
 
+    private Closure<String> snapshotCreator = PredefinedSnapshotCreator.SIMPLE.snapshotCreator
+
     private boolean sanitizeVersion = true
 
     private VersionPropertiesBuilder() {
@@ -32,6 +35,7 @@ class VersionPropertiesBuilder {
             forceSnapshot,
             ignoreUncommittedChanges,
             versionCreator,
+            snapshotCreator,
             PredefinedVersionIncrementer.versionIncrementerFor('incrementPatch'),
             sanitizeVersion,
             useHighestVersion,
@@ -58,7 +62,7 @@ class VersionPropertiesBuilder {
         this.useHighestVersion = true
         return this
     }
-    
+
     VersionPropertiesBuilder supportMonorepos(MonorepoProperties monorepoProperties) {
         this.monorepoProperties = monorepoProperties
         return this
@@ -66,6 +70,11 @@ class VersionPropertiesBuilder {
 
     VersionPropertiesBuilder withVersionCreator(Closure<String> creator) {
         this.versionCreator = creator
+        return this
+    }
+
+    VersionPropertiesBuilder withSnapshotCreator(Closure<String> creator) {
+        this.snapshotCreator = creator
         return this
     }
 


### PR DESCRIPTION
using similar mechanism as with versionCreator, user can provider closure snapshotCreator
closure gives full freedom to customize snapshot i.e. as timestamp

it is addressing https://github.com/allegro/axion-release-plugin/issues/327