### PR TITLE
Bump Gradle to 7.1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'com.gradle.plugin-publish' version '0.12.0'
     id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
-    id 'com.coditory.integration-test' version "1.2.1"
+    id 'com.coditory.integration-test' version "1.0.5"
     id 'com.adarshr.test-logger' version '3.0.0'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,3 @@
-import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
-import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
-import com.bmuschko.gradle.docker.tasks.container.DockerStopContainer
-import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
 
 plugins {
@@ -14,10 +10,9 @@ plugins {
     id 'com.github.kt3k.coveralls' version '2.8.2'
     id 'com.gradle.plugin-publish' version '0.12.0'
     id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
-    id 'com.coditory.integration-test' version "1.0.5"
-    id 'com.adarshr.test-logger' version '2.1.1'
+    id 'com.coditory.integration-test' version "1.2.1"
+    id 'com.adarshr.test-logger' version '3.0.0'
     id 'com.github.johnrengelman.shadow' version '6.1.0'
-    id 'com.bmuschko.docker-remote-api' version '3.2.1'
 }
 
 scmVersion {
@@ -62,28 +57,14 @@ sourceSets {
         java { srcDirs = [] }    // no source dirs for the java compiler
         groovy { srcDirs = ["src/main/java", "src/main/groovy"] }  // compile   everything in src/ with groovy
     }
-
-    remoteTest {
-        java.srcDir project.file('src/test-remote/java')
-        groovy.srcDir project.file('src/test-remote/groovy')
-
-        resources.srcDir project.file('src/test-remote/resources')
-        resources.srcDir project.sourceSets.test.resources
-        resources.srcDir project.sourceSets.main.resources
-
-        compileClasspath = project.sourceSets.main.output +
-            project.sourceSets.test.output +
-            project.configurations.testRuntime
-        runtimeClasspath = output + compileClasspath
-    }
 }
 
 dependencies {
     shadow gradleApi()
     shadow localGroovy()
 
-    compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: versions.jgit
-    compile group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.ssh.jsch', version: versions.jgit
+    implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit', version: versions.jgit
+    implementation group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.ssh.jsch', version: versions.jgit
     runtimeOnly group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.ui', version: versions.jgit
     runtimeOnly group: 'org.eclipse.jgit', name: 'org.eclipse.jgit.gpg.bc', version: versions.jgit
 
@@ -97,18 +78,29 @@ dependencies {
 
     implementation group: 'com.github.zafarkhaja', name: 'java-semver', version: '0.9.0'
 
-    testCompile(group: 'org.ajoberstar.grgit', name: 'grgit-core', version: '4.1.0') {
+    testImplementation(group: 'org.ajoberstar.grgit', name: 'grgit-core', version: '4.1.0') {
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit.ui'
         exclude group: 'org.eclipse.jgit', module: 'org.eclipse.jgit'
     }
 
-    testCompile group: 'org.spockframework', name: 'spock-core', version: '1.3-groovy-2.5'
-    testCompile group: 'cglib', name: 'cglib-nodep', version: '3.1'
-    testCompile group: 'org.objenesis', name: 'objenesis', version: '2.4'
-    testCompile group: 'org.apache.sshd', name: 'sshd-core', version: '1.6.0'
-    testCompile group: 'org.apache.sshd', name: 'sshd-git', version: '1.6.0'
+    testImplementation group: 'org.testcontainers', name: 'spock', version: '1.15.3'
+    testImplementation group: 'org.codehaus.groovy', name: 'groovy-all', version: '3.0.7'
+    testImplementation group: 'org.spockframework', name: 'spock-core', version: '2.0-groovy-3.0'
+    testImplementation group: 'cglib', name: 'cglib-nodep', version: '3.1'
+    testImplementation group: 'org.objenesis', name: 'objenesis', version: '2.4'
+    testImplementation group: 'org.apache.sshd', name: 'sshd-core', version: '1.6.0'
+    testImplementation group: 'org.apache.sshd', name: 'sshd-git', version: '1.6.0'
 
-    testCompile gradleTestKit()
+    testImplementation gradleTestKit()
+}
+
+tasks.withType(Test) {
+    useJUnitPlatform()
+}
+
+wrapper {
+    gradleVersion = '7.1.1'
+    distributionType = Wrapper.DistributionType.BIN
 }
 
 task relocateShadowJar(type: ConfigureShadowRelocation) {
@@ -121,48 +113,7 @@ shadowJar {
     archiveClassifier.set('')
 }
 
-project.configurations {
-    remoteTest {
-        extendsFrom project.configurations.testRuntime
-        description = 'Dependencies for tests with Docker'
-        transitive = true
-        visible = true
-    }
-}
-
-task buildDockerImage(type: DockerBuildImage) {
-    inputDir = file('docker')
-    tag = 'test/axion-release-remote:latest'
-}
-
-task createDockerContainer(type: DockerCreateContainer) {
-    dependsOn buildDockerImage
-    targetImageId { buildDockerImage.getImageId() }
-    portBindings = ['2222:22']
-}
-
-task startDockerContainer(type: DockerStartContainer) {
-    dependsOn createDockerContainer
-    targetContainerId { createDockerContainer.getContainerId() }
-}
-
-task stopDockerContainer(type: DockerStopContainer) {
-    targetContainerId { createDockerContainer.getContainerId() }
-}
-
-task remoteTest(type: Test) {
-    testClassesDirs = project.sourceSets.remoteTest.output.classesDirs
-    classpath = project.sourceSets.main.output +
-        project.sourceSets.test.output +
-        project.sourceSets.remoteTest.runtimeClasspath +
-        project.configurations.testRuntime +
-        project.configurations.remoteTestRuntime
-
-    dependsOn startDockerContainer
-    finalizedBy stopDockerContainer
-}
-
-tasks.check.dependsOn integrationTest, remoteTest
+tasks.check.dependsOn test, integrationTest
 
 gradlePlugin {
     testSourceSets project.sourceSets.integration

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.1.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.8.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/BaseIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/BaseIntegrationTest.groovy
@@ -6,15 +6,15 @@ import org.gradle.testkit.runner.GradleRunner
 class BaseIntegrationTest extends RepositoryBasedTest {
 
     File buildFile() {
-        return temporaryFolder.newFile('build.gradle')
+        return new FileTreeBuilder(temporaryFolder).file("build.gradle","")
     }
 
     File newFile(String name) {
-        return temporaryFolder.newFile(name)
+        return new FileTreeBuilder(temporaryFolder).file(name,"")
     }
 
     void buildFile(String contents) {
-        buildFile() << """
+        new FileTreeBuilder(temporaryFolder).file("build.gradle", """
         plugins {
             id 'pl.allegro.tech.build.axion-release'
         }
@@ -23,16 +23,16 @@ class BaseIntegrationTest extends RepositoryBasedTest {
             """
 
         project.version = scmVersion.version
-        """
+        """)
     }
 
     void vanillaBuildFile(String contents) {
-        buildFile() << contents
+        new FileTreeBuilder(temporaryFolder).file("build.gradle", contents)
     }
 
     GradleRunner gradle() {
         return GradleRunner.create()
-            .withProjectDir(directory)
+            .withProjectDir(temporaryFolder)
             .withPluginClasspath()
     }
 

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/ExtendingTasksIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/ExtendingTasksIntegrationTest.groovy
@@ -34,7 +34,7 @@ class ExtendingTasksIntegrationTest extends BaseIntegrationTest {
         task << [
             'CreateReleaseTask',
             'MarkNextVersionTask',
-            'OutputCurrentVersionTask',
+            // 'OutputCurrentVersionTask', FIXME causes test to fail - Type 'pl.allegro.tech.build.axion.release.OutputCurrentVersionTask' property 'versionConfig.versionIncrementer.creator' is missing an input or output annotation
             'PushReleaseTask',
             'ReleaseTask',
             'VerifyReleaseTask'

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/ExtendingTasksIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/ExtendingTasksIntegrationTest.groovy
@@ -34,7 +34,7 @@ class ExtendingTasksIntegrationTest extends BaseIntegrationTest {
         task << [
             'CreateReleaseTask',
             'MarkNextVersionTask',
-            // 'OutputCurrentVersionTask', FIXME causes test to fail - Type 'pl.allegro.tech.build.axion.release.OutputCurrentVersionTask' property 'versionConfig.versionIncrementer.creator' is missing an input or output annotation
+            'OutputCurrentVersionTask',
             'PushReleaseTask',
             'ReleaseTask',
             'VerifyReleaseTask'

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/MultiModuleProjectIntegrationTest.groovy
@@ -7,7 +7,7 @@ import java.util.stream.Collectors
 class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
 
     File getSubmoduleDir(String projectName) {
-        return new File(temporaryFolder.root, projectName)
+        return new File(temporaryFolder, projectName)
     }
 
     void generateSubmoduleBuildFile(String projectName) {
@@ -59,8 +59,8 @@ class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
         }
         '''
         )
-        generateSettingsFile(temporaryFolder.root, submodules)
-        generateGitIgnoreFile(temporaryFolder.root)
+        generateSettingsFile(temporaryFolder, submodules)
+        generateGitIgnoreFile(temporaryFolder)
 
         repository.commit(['.'], "initial commit of top level project")
 
@@ -156,7 +156,7 @@ class MultiModuleProjectIntegrationTest extends BaseIntegrationTest {
     def "change to root project should not change child project versions"() {
         given:
         initialProjectConfiguration()
-        File dummy = new File(temporaryFolder.root, "dummy.txt")
+        File dummy = new File(temporaryFolder, "dummy.txt")
         dummy.createNewFile()
         repository.commit(["dummy.txt"], "commit parent project")
         runGradle(":release", "-Prelease.version=4.0.0", '-Prelease.localOnly', '-Prelease.disableChecks')

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
@@ -16,7 +16,7 @@ import pl.allegro.tech.build.axion.release.infrastructure.git.SshConnector
 import spock.lang.Shared
 import spock.lang.Specification
 
-import java.nio.file.Path
+import java.nio.file.Paths
 
 import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullPrefix
 
@@ -26,7 +26,7 @@ class RemoteRejectionTest extends Specification {
     @Shared
     GenericContainer gitServerContainer = new GenericContainer(
         new ImageFromDockerfile("test/axion-release-remote:latest", true)
-            .withDockerfile(Path.of("docker/Dockerfile")))
+            .withDockerfile(Paths.get("docker/Dockerfile")))
         .withExposedPorts(22)
 
 

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
@@ -4,20 +4,31 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.TransportConfigCallback
 import org.eclipse.jgit.transport.SshTransport
 import org.eclipse.jgit.transport.Transport
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.images.builder.ImageFromDockerfile
+import org.testcontainers.spock.Testcontainers
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilder
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult
 import pl.allegro.tech.build.axion.release.infrastructure.git.GitRepository
 import pl.allegro.tech.build.axion.release.infrastructure.git.SshConnector
+import spock.lang.Shared
 import spock.lang.Specification
 
-import static pl.allegro.tech.build.axion.release.TagPrefixConf.*
+import java.nio.file.Path
 
+import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullPrefix
+
+@Testcontainers
 class RemoteRejectionTest extends Specification {
 
-    // defined in Docker run script in build.gradle
-    private static final int SSH_PORT = 2222
+    @Shared
+    GenericContainer gitServerContainer = new GenericContainer(
+        new ImageFromDockerfile("test/axion-release-remote:latest", true)
+            .withDockerfile(Path.of("docker/Dockerfile")))
+        .withExposedPorts(22)
+
 
     def "should return error on push failure"() {
         given:
@@ -32,7 +43,7 @@ class RemoteRejectionTest extends Specification {
                     sshTransport.setSshSessionFactory(new SshConnector(ScmIdentity.defaultIdentityWithoutAgents()))
                 }
             })
-            .setURI("ssh://git@localhost:${SSH_PORT}/git-server/repos/rejecting-repo")
+            .setURI("ssh://git@localhost:${gitServerContainer.firstMappedPort}/git-server/repos/rejecting-repo")
             .call()
 
         GitRepository repository = new GitRepository(ScmPropertiesBuilder.scmProperties(repoDir).build())

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/RepositorylessIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/RepositorylessIntegrationTest.groovy
@@ -2,35 +2,28 @@ package pl.allegro.tech.build.axion.release
 
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+import spock.lang.TempDir
 
 class RepositorylessIntegrationTest extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder = new TemporaryFolder()
-
-    File directory
-
-    void setup() {
-        directory = temporaryFolder.root
-    }
+    @TempDir
+    File temporaryFolder
 
     def "should not fail build when calling currentVersion task on project without repo"() {
         given:
-        File build = temporaryFolder.newFile('build.gradle')
-        build << """
+        new FileTreeBuilder(temporaryFolder).file("build.gradle",
+            """
         plugins {
             id 'pl.allegro.tech.build.axion-release'
         }
 
         project.version = scmVersion.version
-        """
+        """)
 
         when:
         def result = GradleRunner.create()
-            .withProjectDir(directory)
+            .withProjectDir(temporaryFolder)
             .withPluginClasspath()
             .withArguments('currentVersion', '-s')
             .build()

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseIntegrationTest.groovy
@@ -7,7 +7,7 @@ class VerifyReleaseIntegrationTest extends BaseIntegrationTest {
     def "should print changes in Git as seen by axion-release"() {
         given:
         buildFile('')
-        temporaryFolder.newFile('my-uncommitted-file') <<  "hello"
+        new FileTreeBuilder(temporaryFolder).file('my-uncommitted-file', "hello")
 
         when:
         def result = runGradle('verifyRelease', '-Prelease.dryRun', '-Prelease.localOnly')

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -48,7 +48,7 @@ class VersionConfig {
     Map<String, Object> branchVersionCreator = [:]
 
     @Nested
-    Closure versionIncrementer = PredefinedVersionIncrementer.versionIncrementerFor('incrementPatch')
+    Closure versionIncrementer = PredefinedVersionIncrementer.INCREMENT_PATCH.versionIncrementer
 
     @Input
     Map<String, Object> branchVersionIncrementer = [:]

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -48,7 +48,7 @@ class VersionConfig {
     Map<String, Object> branchVersionCreator = [:]
 
     @Nested
-    Closure versionIncrementer = PredefinedVersionIncrementer.INCREMENT_PATCH.versionIncrementer
+    Closure versionIncrementer = { VersionIncrementerContext context -> return context.currentVersion.incrementPatchVersion() }
 
     @Input
     Map<String, Object> branchVersionIncrementer = [:]

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/CommitHookAction.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/hooks/CommitHookAction.java
@@ -24,7 +24,7 @@ public class CommitHookAction implements ReleaseHookAction {
 
     @Override
     public void act(HookContext hookContext) {
-        String message = (customAction.call(hookContext.getCurrentVersion(), hookContext.getPosition())).toString();
+        String message = (customAction.call(hookContext.getReleaseVersion(), hookContext.getPosition())).toString();
         hookContext.commit(hookContext.getPatternsToCommit(), message);
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/RepositoryBasedTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/RepositoryBasedTest.groovy
@@ -1,8 +1,6 @@
 package pl.allegro.tech.build.axion.release
 
 import org.ajoberstar.grgit.Grgit
-import org.junit.Rule
-import org.junit.rules.TemporaryFolder
 import pl.allegro.tech.build.axion.release.domain.LocalOnlyResolver
 import pl.allegro.tech.build.axion.release.domain.properties.PropertiesBuilder
 import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties
@@ -10,35 +8,33 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 import pl.allegro.tech.build.axion.release.infrastructure.di.ScmRepositoryFactory
 import spock.lang.Specification
+import spock.lang.TempDir
 
 import static pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilder.scmProperties
 
 class RepositoryBasedTest extends Specification {
 
-    @Rule
-    TemporaryFolder temporaryFolder = new TemporaryFolder()
-
-    File directory
+    @TempDir
+    File temporaryFolder
 
     Context context
 
     ScmRepository repository
 
     void setup() {
-        directory = temporaryFolder.root
-        def rawRepository = Grgit.init(dir: directory)
+        def rawRepository = Grgit.init(dir: temporaryFolder)
 
         // let's make sure, not to use system wide user settings in tests
         rawRepository.repository.jgit.repository.config.baseConfig.clear()
 
-        ScmProperties scmProperties = scmProperties(directory).build()
+        ScmProperties scmProperties = scmProperties(temporaryFolder).build()
         ScmRepository scmRepository = ScmRepositoryFactory.create(scmProperties)
 
         context = new Context(
                 PropertiesBuilder.properties().build(),
                 scmRepository,
                 scmProperties,
-                directory,
+                temporaryFolder,
                 new LocalOnlyResolver(true)
         )
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverSubfolderTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverSubfolderTest.groovy
@@ -1,7 +1,6 @@
 package pl.allegro.tech.build.axion.release.domain
 
 import pl.allegro.tech.build.axion.release.RepositoryBasedTest
-import pl.allegro.tech.build.axion.release.TagPrefixConf
 import pl.allegro.tech.build.axion.release.domain.properties.*
 import pl.allegro.tech.build.axion.release.infrastructure.di.Context
 import spock.lang.Shared
@@ -208,8 +207,8 @@ class VersionResolverSubfolderTest extends RepositoryBasedTest {
         context = new Context(
             PropertiesBuilder.properties().withVersionRules(versionRules).build(),
             context.repository(),
-            scmProperties(directory).build(),
-            directory,
+            scmProperties(temporaryFolder).build(),
+            temporaryFolder,
             new LocalOnlyResolver(true)
         )
 
@@ -217,8 +216,8 @@ class VersionResolverSubfolderTest extends RepositoryBasedTest {
     }
 
     private void createAndCommitFileInSubfolder(String path, String filename) {
-        def subfolder = new File(directory, path)
-        def dummyFile = new File(directory, "${path}/${filename}")
+        def subfolder = new File(temporaryFolder, path)
+        def dummyFile = new File(temporaryFolder, "${path}/${filename}")
         subfolder.mkdirs()
         dummyFile.createNewFile()
         repository.commit(['.'], "create file ${path}/${filename}")


### PR DESCRIPTION
Simplified configuration - use testcontainers instead of gradle tasks to
setup docker test.

Bump groovy to 3.x (implicitly by bumping gradle)
Bump spock to 2.x, use `@TempDir` instead of Junit4 `TemporaryFolder` rule

Explicit Gradle version and distribution type in build.gradle