### PR TITLE
Improve RemoteRejection test

### DIFF
--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/RemoteRejectionTest.groovy
@@ -43,7 +43,7 @@ class RemoteRejectionTest extends Specification {
                     sshTransport.setSshSessionFactory(new SshConnector(ScmIdentity.defaultIdentityWithoutAgents()))
                 }
             })
-            .setURI("ssh://git@localhost:${gitServerContainer.firstMappedPort}/git-server/repos/rejecting-repo")
+            .setURI("ssh://git@${gitServerContainer.getContainerIpAddress()}:${gitServerContainer.firstMappedPort}/git-server/repos/rejecting-repo")
             .call()
 
         GitRepository repository = new GitRepository(ScmPropertiesBuilder.scmProperties(repoDir).build())


### PR DESCRIPTION
Docker container can be hosted on different IP address than localhost