### PR TITLE
Remove slf4j-api module from shadow jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -95,6 +95,11 @@ dependencies {
     testImplementation gradleTestKit()
 }
 
+// Exclude transitive slf4j-api dependency from being embedded into the shadow jar
+configurations.runtimeClasspath {
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+}
+
 tasks.withType(Test) {
     useJUnitPlatform()
 }


### PR DESCRIPTION
`slf4j-api` was included as a transitive dependency of multiple `jgit` modules. Because `jgit` is part of `runtimeClasspath` configuration `slf4j-api` ended in that configuration too despite being also included in `shadow` configuration as part of `gradleApi()`. Because of that it ended up being embedded in the shadow jar. Excluding it manually from `runtimeClasspath` configuration excluded it from the shadow jar.
Because of slf4j-api being included in the shadow jar with a modified package (relocation) following warning is printed during configuration phrase of user projects:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
```

This change fixes #426