### PR TITLE
Document how to override the branch name on Gitlab CI

### DIFF
--- a/docs/configuration/ci_servers.md
+++ b/docs/configuration/ci_servers.md
@@ -130,10 +130,12 @@ Example:
       image: ....
       script: 
        - git remote set-url origin ${CI_SERVER_URL}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}.git
-       - ./gradlew release -Prelease.disableChecks -Prelease.pushTagsOnly -Prelease.customUsername=${PROJECT_ACCESS_TOKEN_BOT_NAME} -Prelease.customPassword=${PROJECT_ACCESS_TOKEN}
+       - ./gradlew release -Prelease.disableChecks -Prelease.pushTagsOnly -Prelease.overriddenBranchName=${CI_COMMIT_BRANCH} -Prelease.customUsername=${PROJECT_ACCESS_TOKEN_BOT_NAME} -Prelease.customPassword=${PROJECT_ACCESS_TOKEN}
 
 NOTE: You need to set the git remote url first, as GitLab's default cloned project url will have added the non repo-write permision [gitlab-ci-token](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html) to the origin url.
 
 
 Disabling checks is necessary because `axion-release` is not able to verify if current commit is ahead of remote. 
 Setting pushTagsOnly ensures that git will not throw an error by attempting to push commits while not working on a branch.
+
+Since Gitlab will do a detached head checkout, the branch name has to be overridden when `versionWithBranch` is used.


### PR DESCRIPTION
Improves #443.

I did not test releasing yet, but I assume it is not really connected to this setting.