### PR TITLE
Update version.md

### DIFF
--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -31,7 +31,7 @@ calculating current version. Prefix can be set using
         }
     }
 
-Default prefix is `release`.
+Default prefix is `v`.
 
 There is also an option to set prefix per-branch (i.e. to use different
 version prefix on `legacy-` branches):


### PR DESCRIPTION
I guess that the documentation is not correct at this one point. The version prefix is by default `v` and not `release`. 
Changed it.