### PR TITLE
PredefinedVersionCreator: added versionWithCommitHash

### DIFF
--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -322,6 +322,18 @@ This version creator appends branch name to version unless you are on
     decorate(version: '0.1.0', branch: 'master') == 0.1.0
     decorate(version: '0.1.0', branch: 'my-special-branch') == 0.1.0-my-special-branch
 
+#### versionWithCommitHash
+
+    scmVersion {
+        versionCreator('versionWithCommitHash')
+    }
+
+This version creator appends short SHA-1 hash to version unless you are on
+*main*/*master* or *detached HEAD*:
+
+    decorate(version: '0.1.0', branch: 'main') == 0.1.0
+    decorate(version: '0.1.0', branch: 'some-other-branch', revision: 'c1439767113643abda121896ee3fa42b500f16d0') == 0.1.0-c143976
+
 ### Custom version creator
 
 Custom version creators can be implemented by creating closure:

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreator.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreator.groovy
@@ -16,6 +16,13 @@ enum PredefinedVersionCreator {
             return "$versionFromTag-$position.branch".toString()
         }
         return versionFromTag
+    }),
+
+    VERSION_WITH_COMMIT_HASH('versionWithCommitHash', { String versionFromTag, ScmPosition position ->
+    if ((position.branch != 'master' && position.branch != 'main') && position.branch != 'HEAD') {
+        return "$versionFromTag-$position.shortRevision".toString()
+    }
+    return versionFromTag
     })
 
     private final String type

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreatorTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreatorTest.groovy
@@ -23,6 +23,16 @@ class PredefinedVersionCreatorTest extends Specification {
         PredefinedVersionCreator.VERSION_WITH_BRANCH.versionCreator.apply('version', scmPosition('branch')) == 'version-branch'
     }
 
+    def "versionWithCommitHash version creator should return simple version when on main"() {
+        expect:
+        PredefinedVersionCreator.VERSION_WITH_COMMIT_HASH.versionCreator.apply('version', scmPosition('main')) == 'version'
+    }
+
+    def "versionWithCommitHash version creator should return version with appended short SHA-1 hash when not on main"() {
+        expect:
+        PredefinedVersionCreator.VERSION_WITH_COMMIT_HASH.versionCreator.apply('version', scmPosition('branch')) == 'version-c143976'
+    }
+
     def "should return version creator of given type"() {
         expect:
         PredefinedVersionCreator.versionCreatorFor('simple').apply('version', null) == 'version'


### PR DESCRIPTION
I added a new PredefinedVersionCreator `versionWithCommitHash` which helps to indicate **releases** which where _not created on the main branch_ by appending the _short SHA-1 hash_