### PR TITLE
Use @InputFile on RepositoryConfig#getCustomKeyFile

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
@@ -7,6 +7,7 @@ import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 
 import javax.inject.Inject
@@ -56,7 +57,7 @@ abstract class RepositoryConfig extends BaseExtension {
     @Optional
     abstract Property<String> getCustomKey()
 
-    @Input
+    @InputFile
     @Optional
     abstract RegularFileProperty getCustomKeyFile()
 


### PR DESCRIPTION
Gradle displays this message (without failing) with version 7.6:

    > Task :currentVersion
    Execution optimizations have been disabled for task ':currentVersion' to ensure correctness due to the following reasons:
      - In plugin 'pl.allegro.tech.build.axion.release.ReleasePlugin$Inject' type 'pl.allegro.tech.build.axion.release.OutputCurrentVersionTask' property 'versionConfig.repository.customKeyFile' has @Input annotation used on property of type 'RegularFileProperty'. Reason: A property of type 'RegularFileProperty' annotated with @Input cannot determine how to interpret the file. Please refer to https://docs.gradle.org/7.6/userguide/validation_problems.html#incorrect_use_of_input_annotation for more details about this problem.

Fixes #559