### PR TITLE
Fix issue with Push command being reused.

### DIFF
--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -132,11 +132,9 @@ public class GitRepository implements ScmRepository {
     }
 
     public ScmPushResult push(ScmIdentity identity, ScmPushOptions pushOptions, boolean all) {
-        PushCommand command = pushCommand(identity, pushOptions.getRemote(), all);
-
-        // command has to be called twice:
-        // once for commits (only if needed)
+        // push once for commits (only if needed)
         if (!pushOptions.isPushTagsOnly()) {
+            PushCommand command = pushCommand(identity, pushOptions.getRemote(), all);
             ScmPushResult result = verifyPushResults(callPush(command));
             if (!result.isSuccess()) {
                 return result;
@@ -144,7 +142,9 @@ public class GitRepository implements ScmRepository {
 
         }
 
-        // and another time for tags
+        // and again for tags
+        // Note: push commands can *not* be re-used.
+        PushCommand command = pushCommand(identity, pushOptions.getRemote(), all);
         return verifyPushResults(callPush(command.setPushTags()));
     }
 


### PR DESCRIPTION
fixes: https://github.com/allegro/axion-release-plugin/issues/573

Issue arises as later versions of Push command can not be reused.  This change was introduced in `jgit` `6.1.x`. However, this version of `jgit` requires Java 11, whereas this project current uses Java 8. Hence, can't easily add test...