### PR TITLE
Update to JDK11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 1.8
+      - name: Set up JDK
         uses: actions/setup-java@v2
         with:
             distribution: 'temurin'
-            java-version: '8'
+            java-version: '11'
             cache: 'gradle'
 
       - name: Test with Gradle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,10 +14,12 @@ jobs:
         with:
           fetch-depth: 0
       - uses: gradle/wrapper-validation-action@v1
-      - name: Set up JDK 1.8
+      - name: Set up JDK
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+            distribution: 'temurin'
+            java-version: '11'
+            cache: 'gradle'
       - name: Publish to gradle
         run: ./gradlew publishPlugin -Dgradle.publish.key=${GRADLE_PORTAL_KEY} -Dgradle.publish.secret=${GRADLE_PORTAL_SECRET}
         env:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     jacoco
     id("pl.allegro.tech.build.axion-release") version "1.14.3"
     id("com.github.kt3k.coveralls") version "2.12.0"
-    id("com.gradle.plugin-publish") version "0.21.0"
+    id("com.gradle.plugin-publish") version "1.1.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("com.coditory.integration-test") version "1.4.5"
     id("com.adarshr.test-logger") version "3.0.0"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ java {
     withSourcesJar()
     withJavadocJar()
     toolchain {
-        languageVersion.set(JavaLanguageVersion.of(8))
+        languageVersion.set(JavaLanguageVersion.of(11))
     }
 }
 
@@ -36,7 +36,7 @@ repositories {
 }
 
 object Versions {
-    const val jgit = "5.13.1.202206130422-r"
+    const val jgit = "6.4.0.202211300538-r"
     const val jsch = "0.1.55"
     const val jschAgent = "0.0.9"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     jacoco
     id("pl.allegro.tech.build.axion-release") version "1.14.3"
     id("com.github.kt3k.coveralls") version "2.12.0"
-    id("com.gradle.plugin-publish") version "1.1.0"
+    id("com.gradle.plugin-publish") version "0.21.0"
     id("io.github.gradle-nexus.publish-plugin") version "1.1.0"
     id("com.coditory.integration-test") version "1.4.5"
     id("com.adarshr.test-logger") version "3.0.0"

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/SshConnector.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/SshConnector.java
@@ -3,8 +3,8 @@ package pl.allegro.tech.build.axion.release.infrastructure.git;
 import com.jcraft.jsch.JSch;
 import com.jcraft.jsch.JSchException;
 import com.jcraft.jsch.Session;
-import org.eclipse.jgit.transport.JschConfigSessionFactory;
-import org.eclipse.jgit.transport.OpenSshConfig;
+import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory;
+import org.eclipse.jgit.transport.ssh.jsch.OpenSshConfig;
 import org.eclipse.jgit.util.FS;
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity;
 


### PR DESCRIPTION
**Breaking change**: Dropping support for Java8 is a breaking change for anyone using Java8. I recommend bumping the major version.

Updates tool chain to Java 11 (LTS), and updates the JGit dependency to the latest (which requires J11). This [highlighted](https://github.com/allegro/axion-release-plugin/actions/runs/4128657832/jobs/7133366021) issue https://github.com/allegro/axion-release-plugin/issues/573 until the [fix](https://github.com/allegro/axion-release-plugin/pull/575) was merged.

Updating JGIt to the latest version also highlighted and issue with a package name change for classes in the `org.eclipse.jgit:org.eclipse.jgit.ssh.jsch` dependency: both `JschConfigSessionFactory` and `OpenSshConfig` referenced from `SshConnector` have moved between JGit version 5.x.x and 6.x.x.

 **Implications**: users of the current plugin with a Gradle build environment that's pulling JGit 6.x.x will likely encounter `ClassNotFound` style errors if using the `SshConnector` class.

Build is now green.