### PR TITLE
[Documentation] Note about GitHub Action token permissions

### DIFF
--- a/docs/configuration/ci_servers.md
+++ b/docs/configuration/ci_servers.md
@@ -117,6 +117,8 @@ In order to push tags into the repository release step must use GitHub actor and
               -Prelease.customUsername=${{ github.actor }} \
               -Prelease.customPassword=${{ github.token }}
 
+> Your GitHub token requires write permissions to successfully push tags into the repository.
+> You can grant write permissions to your token using `Settings -> Actions -> General -> Workflow permissions` option.
 
 ## GitLab CI
 

--- a/docs/configuration/ci_servers.md
+++ b/docs/configuration/ci_servers.md
@@ -90,17 +90,17 @@ you need to override branch name with `overriddenBranchName` flag and set it to
 
 ## GitHub Actions
 
-Your workflow needs to use `actions/checkout@v2` with configuration to [fetch tags](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches):
+Your workflow needs to use `actions/checkout@v3` with configuration to [fetch tags](https://github.com/actions/checkout#fetch-all-history-for-all-tags-and-branches):
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
 When you have a lot of tags/commit you can speed up your build - plugin successfully works using local git shallow repository, but you must run `git fetch --tags --unshallow` before running `./gradlew release` - that will ensure the plugin has all the info it needs to run.
 
     steps:
-        - uses: actions/checkout@v2
+        - uses: actions/checkout@v3
         - name: Publish using Axion
           run: |
               # Fetch a full copy of the repo, as required by release plugin:

--- a/docs/configuration/ci_servers.md
+++ b/docs/configuration/ci_servers.md
@@ -117,8 +117,8 @@ In order to push tags into the repository release step must use GitHub actor and
               -Prelease.customUsername=${{ github.actor }} \
               -Prelease.customPassword=${{ github.token }}
 
-> Your GitHub token requires write permissions to successfully push tags into the repository.
-> You can grant write permissions to your token using `Settings -> Actions -> General -> Workflow permissions` option.
+> GitHub token requires write permissions to push tags into the repository.
+> To grant GitHub token write permissions use `Settings -> Actions -> General -> Workflow permissions -> Read and write permissions` option.
 
 ## GitLab CI
 


### PR DESCRIPTION
When I tried to use `axion-release-plugin` with GitHub Actions, I ran into a problem while running `release` task:

```yaml
- name: Release
  if: github.ref == 'refs/heads/main'
  run: ./gradlew release -Prelease.customPassword=${{ github.token }} -Prelease.customUsername=${{ github.actor }} -Prelease.forceVersion=${{ github.event.inputs.forceVersion }}
```

**Error message:**
```
BUILD FAILED in 22s
> Task :release FAILED
Creating tag: mongo-index-copy-1.0.0
Pushing all to remote: origin
Exception occurred during push: org.eclipse.jgit.api.errors.TransportException: https://github.com/pitagoras3/mongo-index-copy: git-receive-pack not permitted on 'https://github.com/pitagoras3/mongo-index-copy/'
2 actionable tasks: 2 executed
Error: Process completed with exit code 1.
```

It occurred that my GitHub token didn't had write permissions to the repository. To make it work, I switched on `Settings -> Actions -> General -> Workflow permissions -> Read and write permissions` option, and added this info to `axion-release-plugin` documentation for others :)