### PR TITLE
Switching to jsch implementation by mwiede

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,13 +62,26 @@ dependencies {
     implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     implementation("org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:$jgitVersion")
     implementation("com.github.mwiede:jsch:$jschVersion")
-    implementation("com.jcraft:jsch.agentproxy.core:$jschAgentVersion")
-    implementation("com.jcraft:jsch.agentproxy.jsch:$jschAgentVersion")
-    implementation("com.jcraft:jsch.agentproxy.sshagent:$jschAgentVersion")
-    implementation("com.jcraft:jsch.agentproxy.pageant:$jschAgentVersion")
-    implementation("com.jcraft:jsch.agentproxy.usocket-jna:$jschAgentVersion")
-    implementation("com.jcraft:jsch.agentproxy.usocket-nc:$jschAgentVersion")
+    implementation("com.jcraft:jsch.agentproxy.core:$jschAgentVersion") {
+        exclude("com.jcraft", "jsch")
+    }
+    implementation("com.jcraft:jsch.agentproxy.jsch:$jschAgentVersion") {
+        exclude("com.jcraft", "jsch")
+    }
+    implementation("com.jcraft:jsch.agentproxy.sshagent:$jschAgentVersion") {
+        exclude("com.jcraft", "jsch")
+    }
+    implementation("com.jcraft:jsch.agentproxy.pageant:$jschAgentVersion") {
+        exclude("com.jcraft", "jsch")
+    }
+    implementation("com.jcraft:jsch.agentproxy.usocket-jna:$jschAgentVersion") {
+        exclude("com.jcraft", "jsch")
+    }
+    implementation("com.jcraft:jsch.agentproxy.usocket-nc:$jschAgentVersion") {
+        exclude("com.jcraft", "jsch")
+    }
     implementation("com.github.zafarkhaja:java-semver:0.9.0")
+    implementation("org.bouncycastle:bcprov-jdk18on:1.73")
 
     testImplementation("org.ajoberstar.grgit:grgit-core:4.1.0") {
         exclude("org.eclipse.jgit", "org.eclipse.jgit.ui")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -49,7 +49,7 @@ sourceSets {
 }
 
 val jgitVersion = "6.5.0.202303070854-r"
-val jschVersion = "0.1.55"
+val jschVersion = "0.2.8"
 val jschAgentVersion = "0.0.9"
 
 dependencies {
@@ -61,7 +61,7 @@ dependencies {
 
     implementation("org.eclipse.jgit:org.eclipse.jgit:$jgitVersion")
     implementation("org.eclipse.jgit:org.eclipse.jgit.ssh.jsch:$jgitVersion")
-    implementation("com.jcraft:jsch:$jschVersion")
+    implementation("com.github.mwiede:jsch:$jschVersion")
     implementation("com.jcraft:jsch.agentproxy.core:$jschAgentVersion")
     implementation("com.jcraft:jsch.agentproxy.jsch:$jschAgentVersion")
     implementation("com.jcraft:jsch.agentproxy.sshagent:$jschAgentVersion")


### PR DESCRIPTION
Hi! 

I discovered that authorization fails with invalid private key error when private key is generated by a new versions of openssh (header that is not supported is : -----BEGIN OPENSSH PRIVATE KEY-----)

The problem is that jsch is not actively maintained, but there is a for, which is.
See: https://stackoverflow.com/questions/73862879/workaround-for-jsch-unsupported-kex-algorithms


After switching to new implementation, problem is solved. Private key is properly used.