### PR TITLE
update next_version.md with correct default strategy

### DIFF
--- a/docs/configuration/next_version.md
+++ b/docs/configuration/next_version.md
@@ -36,7 +36,7 @@ is not incremented:
     2.1.0-SNAPSHOT
 
 To create next version marker use `markNextVersion`. Without parameters next version will be created with default
-version incrementer - incrementMinor, which can be overwritten with `release.incrementer` parameter.
+version incrementer - incrementPatch, which can be overwritten with `release.incrementer` parameter.
 Custom next version can be created along with command line option `release.version`.
 
 Default next version marker serializer/deserializer can be customized


### PR DESCRIPTION
it seems the default behavior is incrementPatch, not incrementMinor - this PR updates the documentation to indicate that (this is in line with the docs on https://axion-release-plugin.readthedocs.io/en/latest/configuration/version/)