### PR TITLE
remove @InputDirectory to avoid memory leak (#561)

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
@@ -1,12 +1,10 @@
 package pl.allegro.tech.build.axion.release.domain
 
 import org.gradle.api.file.Directory
-import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
 import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 
@@ -38,16 +36,16 @@ abstract class RepositoryConfig extends BaseExtension {
         customKey.convention(gradleProperty(CUSTOM_KEY_PROPERTY))
         customKeyFile.convention(gradleProperty(CUSTOM_KEY_FILE_PROPERTY)
             .map({ layout.projectDirectory.file(it) }))
-        directory.convention(repositoryDirectory)
+        directory.convention(repositoryDirectory.asFile.absolutePath)
     }
 
     @Input
     @Optional
     abstract Property<String> getType()
 
-    @InputDirectory
+    @Input
     @Optional
-    abstract DirectoryProperty getDirectory()
+    abstract Property<String> getDirectory()
 
     @Input
     @Optional

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
@@ -8,7 +8,7 @@ class ScmPropertiesFactory {
     static ScmProperties create(VersionConfig config) {
         return new ScmProperties(
             config.repository.type.get(),
-            config.repository.directory.asFile.get(),
+            new File(config.repository.directory.get()),
             config.repository.remote.get(),
             config.repository.pushTagsOnly().get(),
             config.repository.fetchTags().get(),

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfigFactoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfigFactoryTest.groovy
@@ -15,7 +15,7 @@ class RepositoryConfigFactoryTest extends Specification {
         RepositoryConfig config = Fixtures.repositoryConfig(project)
 
         then:
-        config.directory.asFile.get() == project.rootDir
+        new File(config.directory.get()) == project.rootDir
     }
 
     def "should not initialize authorization options when no flags on project"() {


### PR DESCRIPTION
Confirmed [my suspicion](https://github.com/allegro/axion-release-plugin/issues/561#issuecomment-1653540205):

After changing `RepositoryConfig.directory` to `@Input Property<String>`, `./gradlew currentVersion` finishes immediately (again).