### PR TITLE
Fix #387 - prevent JGit from accessing system config to support Gradle configuration cache

### DIFF
--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -27,6 +27,7 @@ import org.eclipse.jgit.transport.RemoteRefUpdate;
 import org.eclipse.jgit.transport.TagOpt;
 import org.eclipse.jgit.transport.URIish;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
+import org.eclipse.jgit.util.SystemReader;
 import org.eclipse.jgit.util.io.DisabledOutputStream;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
@@ -66,6 +67,8 @@ public class GitRepository implements ScmRepository {
     private final ScmProperties properties;
 
     public GitRepository(ScmProperties properties) {
+        SystemReader.setInstance(new SystemReaderWithoutSystemConfig());
+
         try {
             this.repositoryDir = properties.getDirectory();
             this.jgitRepository = Git.open(repositoryDir);

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/SystemReaderWithoutSystemConfig.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/SystemReaderWithoutSystemConfig.java
@@ -1,0 +1,73 @@
+package pl.allegro.tech.build.axion.release.infrastructure.git;
+
+import org.eclipse.jgit.lib.Config;
+import org.eclipse.jgit.storage.file.FileBasedConfig;
+import org.eclipse.jgit.util.FS;
+import org.eclipse.jgit.util.SystemReader;
+
+public class SystemReaderWithoutSystemConfig extends SystemReader
+{
+    private static final SystemReader DefaultSystemReader = SystemReader.getInstance();
+
+    @Override
+    public String getenv(String variable)
+    {
+        return DefaultSystemReader.getenv(variable);
+    }
+
+    @Override
+    public String getHostname()
+    {
+        return DefaultSystemReader.getHostname();
+    }
+
+    @Override
+    public String getProperty(String key)
+    {
+        return DefaultSystemReader.getProperty(key);
+    }
+
+    @Override
+    public long getCurrentTime()
+    {
+        return DefaultSystemReader.getCurrentTime();
+    }
+
+    @Override
+    public int getTimezone(long when)
+    {
+        return DefaultSystemReader.getTimezone(when);
+    }
+
+    @Override
+    public FileBasedConfig openUserConfig(Config parent, FS fs)
+    {
+        return DefaultSystemReader.openUserConfig(parent, fs);
+    }
+
+    @Override
+    public FileBasedConfig openJGitConfig(Config parent, FS fs) {
+        return DefaultSystemReader.openJGitConfig(parent, fs);
+    }
+
+    // Return an empty system configuration to prevent JGit from accessing it
+    // This resolves issues with Gradle being unable to save configuration cache
+    // Based on https://stackoverflow.com/a/59110721
+    @Override
+    public FileBasedConfig openSystemConfig(Config parent, FS fs)
+    {
+        return new FileBasedConfig(parent, null, fs)
+        {
+            @Override
+            public void load()
+            {
+            }
+
+            @Override
+            public boolean isOutdated()
+            {
+                return false;
+            }
+        };
+    }
+}


### PR DESCRIPTION
As described in the [issue](https://github.com/allegro/axion-release-plugin/issues/387) - JGit is accessing system config file,  which breaks Gradle configuration cache. In order to disable this feature in JGit, we need to supply a new `SystemReader` without this functionality before initializing JGit repository. This new `SystemReader` delegates all responsibilities to the original reader, with the exception of loading system config, which is replaced with an empty implementation to prevent access.