### PR TITLE
implement flag overridenIsClean

### DIFF
--- a/docs/configuration/overview.md
+++ b/docs/configuration/overview.md
@@ -75,3 +75,35 @@ All `axion-release-plugin` configuration options:
             aheadOfRemote.set(false) // permanently disable ahead of remote check
         }
     }
+
+All `axion-release-plugin` configuration flags:
+
+- release.customKey
+    - see [Authorization](authorization.md)
+- release.customKeyFile
+    - see [Authorization](authorization.md)
+- release.customKeyPassword
+    - see [Authorization](authorization.md)
+- release.customUsername
+    - see [Authorization](authorization.md) and [CI Servers](ci_servers.md)
+- release.customPassword
+    - see [Authorization](authorization.md) and [CI Servers](ci_servers.md)
+- release.pushTagsOnly
+    - see [Repository](repository.md) and [CI Servers](ci_servers.md)
+- release.attachRemote
+    - see [CI Servers](ci_servers.md)
+- release.overriddenBranchName
+    - possible values: any string like `develop`
+    - usually the plugin detects the branch name automatically. With this flag, the result can be overridden.
+    - see [CI Servers](ci_servers.md)
+- release.overriddenIsClean
+    - default: not set = determine the `isClean`-state
+    - possible values: `true` or `false`
+    - usually the plugin performs a check if the working directory is clean. With this flag, the result of the check can be overridden.
+    - If you have a repository with a lot of files and do not use the isClean-feature, you may set this flag for a speed-up.
+- release.disableSshAgent
+    - default: false
+    - do not use the ssh agent
+- release.fetchTags
+    - default: false
+    - fetch tags from the remote repository

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/BaseExtension.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/BaseExtension.groovy
@@ -23,6 +23,10 @@ abstract class BaseExtension {
         return providers.gradleProperty(name).forUseAtConfigurationTime()
     }
 
+    protected Provider<Boolean> gradlePropertyBoolean(String name) {
+        return gradleProperty(name).map(Boolean::valueOf)
+    }
+
     protected Provider<Boolean> gradlePropertyPresent(String name) {
         return gradleProperty(name).map({true})
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
@@ -20,6 +20,7 @@ abstract class RepositoryConfig extends BaseExtension {
     private static final String RELEASE_PUSH_TAGS_ONLY_PROPERTY = 'release.pushTagsOnly'
     private static final String ATTACH_REMOTE_PROPERTY = 'release.attachRemote'
     private static final String OVERRIDDEN_BRANCH_NAME = 'release.overriddenBranchName'
+    private static final String OVERRIDDEN_IS_CLEAN = 'release.overriddenIsClean'
     private static final String DISABLE_SSH_AGENT = 'release.disableSshAgent'
     private static final String FETCH_TAGS_PROPERTY = 'release.fetchTags'
 
@@ -85,6 +86,10 @@ abstract class RepositoryConfig extends BaseExtension {
 
     Provider<String> overriddenBranch() {
         gradleProperty(OVERRIDDEN_BRANCH_NAME)
+    }
+
+    Provider<Boolean> overriddenIsClean() {
+        gradlePropertyBoolean(OVERRIDDEN_IS_CLEAN)
     }
 
     Provider<Boolean> disableSshAgent() {

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
@@ -15,6 +15,7 @@ class ScmPropertiesFactory {
             config.repository.attachRemote().isPresent(),
             config.repository.attachRemote().getOrNull(),
             config.repository.overriddenBranch().getOrNull(),
+            config.repository.overriddenIsClean().getOrNull(),
             ScmIdentityFactory.create(config.repository, config.repository.disableSshAgent().get())
         )
     }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmProperties.java
@@ -1,6 +1,7 @@
 package pl.allegro.tech.build.axion.release.domain.scm;
 
 import java.io.File;
+import java.util.Optional;
 
 public class ScmProperties {
 
@@ -12,6 +13,7 @@ public class ScmProperties {
     private final boolean attachRemote;
     private final String remoteUrl;
     private final String overriddenBranchName;
+    private final Boolean overriddenIsClean;
     private final ScmIdentity identity;
 
     public ScmProperties(
@@ -23,6 +25,7 @@ public class ScmProperties {
         boolean attachRemote,
         String remoteUrl,
         String overriddenBranchName,
+        Boolean overriddenIsClean,
         ScmIdentity identity
     ) {
         this.type = type;
@@ -33,6 +36,7 @@ public class ScmProperties {
         this.attachRemote = attachRemote;
         this.remoteUrl = remoteUrl;
         this.overriddenBranchName = overriddenBranchName;
+        this.overriddenIsClean = overriddenIsClean;
         this.identity = identity;
     }
 
@@ -70,6 +74,10 @@ public class ScmProperties {
 
     public String getOverriddenBranchName() {
         return overriddenBranchName;
+    }
+
+    public Optional<Boolean> getOverriddenIsClean() {
+        return Optional.ofNullable(overriddenIsClean);
     }
 
     public final ScmIdentity getIdentity() {

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -194,7 +194,7 @@ public class GitRepository implements ScmRepository {
 
         Optional<RemoteRefUpdate> failedRefUpdate = pushResult.getRemoteUpdates().stream().filter(ref ->
             !ref.getStatus().equals(RemoteRefUpdate.Status.OK)
-            && !ref.getStatus().equals(RemoteRefUpdate.Status.UP_TO_DATE)
+                && !ref.getStatus().equals(RemoteRefUpdate.Status.UP_TO_DATE)
         ).findFirst();
 
         boolean isSuccess = !failedRefUpdate.isPresent();
@@ -504,8 +504,16 @@ public class GitRepository implements ScmRepository {
         return config.getSubsections("remote").stream().anyMatch(n -> n.equals(remoteName));
     }
 
+    /**
+     * @return true when there are uncommitted changes. This means: not clean
+     */
     @Override
     public boolean checkUncommittedChanges() {
+        Optional<Boolean> overriddenIsClean = properties.getOverriddenIsClean();
+        if (overriddenIsClean.isPresent()) {
+            // the logic to get the isClean-property is inverted
+            return !overriddenIsClean.get();
+        }
         try {
             return !jgitRepository.status().call().isClean();
         } catch (GitAPIException e) {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
@@ -6,6 +6,7 @@ class ScmPropertiesBuilder {
 
     private String type = 'git'
     private String overriddenBranchName
+    private Boolean overriddenIsClean = null
 
     private ScmPropertiesBuilder(File directory) {
         this.directory = directory
@@ -20,6 +21,11 @@ class ScmPropertiesBuilder {
         return this
     }
 
+    ScmPropertiesBuilder withOverriddenIsClean(Boolean overriddenIsClean) {
+        this.overriddenIsClean = overriddenIsClean
+        return this
+    }
+
     ScmProperties build() {
         return new ScmProperties(
                 type,
@@ -30,6 +36,7 @@ class ScmPropertiesBuilder {
                 false,
                 null,
                 overriddenBranchName,
+                overriddenIsClean,
                 ScmIdentity.defaultIdentityWithoutAgents()
         )
     }


### PR DESCRIPTION
This flag is implemented similar to overriddenBranch and allows to set the "isClean" flag for the repository. Which basically determines if the working tree is dirty or clean.

One use-case is to speed up the computation when running the plugin locally as the isClean-calculation is quite time consuming. Also it may help during development of the version-rules.

This solves one part of issue #736