### PR TITLE
Add gradle task rule for marking the next version

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/BaseAxionTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/BaseAxionTask.groovy
@@ -19,7 +19,7 @@ abstract class BaseAxionTask extends DefaultTask {
     @Inject
     protected abstract ProviderFactory getProviders();
 
-    protected VersionResolutionContext resolutionContext() {
-        return VersionResolutionContext.create(versionConfig, layout.projectDirectory)
+    protected VersionResolutionContext resolutionContext(String nextVersion = null, String versionIncrementerName = null) {
+        return VersionResolutionContext.create(versionConfig, layout.projectDirectory, nextVersion, versionIncrementerName)
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/MarkNextVersionTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/MarkNextVersionTask.groovy
@@ -1,15 +1,18 @@
 package pl.allegro.tech.build.axion.release
 
-
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 import pl.allegro.tech.build.axion.release.domain.NextVersionMarker
 import pl.allegro.tech.build.axion.release.domain.properties.Properties
 import pl.allegro.tech.build.axion.release.infrastructure.di.VersionResolutionContext
 
 abstract class MarkNextVersionTask extends BaseAxionTask {
+    @Input
+    String versionIncrementerName = null;
+
     @TaskAction
     void release() {
-        VersionResolutionContext context = resolutionContext()
+        VersionResolutionContext context = resolutionContext(null, versionIncrementerName)
         NextVersionMarker marker = new NextVersionMarker(context.scmService())
 
         Properties rules = context.rules()

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -59,6 +59,17 @@ abstract class ReleasePlugin implements Plugin<Project> {
             description = 'Creates next version marker tag and pushes it to remote.'
         }
 
+        project.tasks.addRule("Pattern: " + MARK_NEXT_VERSION_TASK + "<VersionIncrementer>: Creates next version marker tag and pushes it to remote, using the specified incrementer.") { String taskName ->
+            if (taskName.startsWith(MARK_NEXT_VERSION_TASK)) {
+                project.tasks.register(taskName, MarkNextVersionTask) {
+                    group = 'Release'
+                    description = 'Creates next version marker tag and pushes it to remote.'
+
+                    versionIncrementerName = taskName.substring(MARK_NEXT_VERSION_TASK.length()).uncapitalize()
+                }
+            }
+        }
+
         project.tasks.register(CURRENT_VERSION_TASK, OutputCurrentVersionTask) {
             group = 'Help'
             description = 'Prints current project version extracted from SCM.'

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/RulesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/RulesFactory.groovy
@@ -10,7 +10,7 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 
 class RulesFactory {
 
-    static Properties create(VersionConfig versionConfig, ScmRepository repository) {
+    static Properties create(VersionConfig versionConfig, ScmRepository repository, String nextVersion = null, String versionIncrementerName = null) {
 
         ScmPosition position = repository.currentPosition()
         setDefaultPrefix(versionConfig.tag, repository)
@@ -20,7 +20,7 @@ class RulesFactory {
             VersionPropertiesFactory.create(versionConfig, position.branch),
             TagPropertiesFactory.create(versionConfig.tag, position.branch),
             versionConfig.checks,
-            versionConfig.nextVersion.nextVersionProperties(),
+            versionConfig.nextVersion.nextVersionProperties(nextVersion, versionIncrementerName),
             HooksPropertiesFactory.create(versionConfig, versionConfig.hooks)
         )
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/VersionResolutionContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/VersionResolutionContext.groovy
@@ -38,12 +38,12 @@ class VersionResolutionContext {
             scmProperties.directory.toPath().relativize(projectRoot.toPath()).toString()))
     }
 
-    static VersionResolutionContext create(VersionConfig versionConfig, Directory projectDirectory) {
+    static VersionResolutionContext create(VersionConfig versionConfig, Directory projectDirectory, String nextVersion = null, String versionIncrementerName = null) {
         ScmProperties scmProperties = ScmPropertiesFactory.create(versionConfig)
         ScmRepository scmRepository = ScmRepositoryFactory.create(scmProperties)
 
         return new VersionResolutionContext(
-            RulesFactory.create(versionConfig, scmRepository),
+            RulesFactory.create(versionConfig, scmRepository, nextVersion, versionIncrementerName),
             scmRepository,
             scmProperties,
             projectDirectory.asFile,

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/NextVersionConfig.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/NextVersionConfig.java
@@ -2,13 +2,13 @@ package pl.allegro.tech.build.axion.release.domain;
 
 import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
-import org.gradle.api.provider.ProviderFactory;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Internal;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties;
-import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties.*;
+import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties.Deserializer;
+import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties.Serializer;
 
 import javax.inject.Inject;
 
@@ -56,20 +56,23 @@ public abstract class NextVersionConfig extends BaseExtension {
         getDeserializer().set(deserializer);
     }
 
-    public NextVersionProperties nextVersionProperties() {
-
+    public NextVersionProperties nextVersionProperties(String nextVersion, String versionIncrementerName) {
         if (getSuffix().get().isEmpty()) {
             String message = "scmVersion.nextVersion.suffix can't be empty! Empty suffix will prevent axion-release from distinguishing nextVersion from regular versions";
             throw new IllegalArgumentException(message);
         }
 
-        return new NextVersionProperties(nextVersion().getOrNull(),
+        return new NextVersionProperties(nextVersion().isPresent() ? versionIncrementerName().getOrNull() : nextVersion,
             getSuffix().get(),
             getSeparator().get(),
-            versionIncrementerName().getOrNull(),
+            versionIncrementerName().isPresent() ? versionIncrementerName().getOrNull() : versionIncrementerName,
             getSerializer().get(),
             getDeserializer().get()
         );
+    }
+
+    public NextVersionProperties nextVersionProperties() {
+        return nextVersionProperties(null, null);
     }
 
     private Provider<String> versionIncrementerName() {


### PR DESCRIPTION
Adds a gradle task rule for incrementing the next version, using the format `markNextVersion[Patch/Minor/Major/MinorIfNotRelease/Prerelease/Branch]`

Fixes #602

Downsides of this approach:
- Tasks are not present in the ide, so it's hard for users to know about them

Upsides of this approach:
- Does not pollute the task list with a bunch of tasks
- Tasks for incrementing the version are only created immediately before the task is executed
- No need to add new tasks if any new version incrementers are added