### PR TITLE
improve ci_servers.md GitLab CI branch override

### DIFF
--- a/docs/configuration/ci_servers.md
+++ b/docs/configuration/ci_servers.md
@@ -132,7 +132,7 @@ Example:
       image: ....
       script:
        - git remote set-url origin ${CI_SERVER_URL}/${CI_PROJECT_NAMESPACE}/${CI_PROJECT_NAME}.git
-       - ./gradlew release -Prelease.disableChecks -Prelease.pushTagsOnly -Prelease.overriddenBranchName=${CI_COMMIT_BRANCH} -Prelease.customUsername=${PROJECT_ACCESS_TOKEN_BOT_NAME} -Prelease.customPassword=${PROJECT_ACCESS_TOKEN}
+       - ./gradlew release -Prelease.disableChecks -Prelease.pushTagsOnly -Prelease.overriddenBranchName=${CI_COMMIT_REF_SLUG} -Prelease.customUsername=${PROJECT_ACCESS_TOKEN_BOT_NAME} -Prelease.customPassword=${PROJECT_ACCESS_TOKEN}
 
 NOTE: You need to set the git remote url first, as GitLab's default cloned project url will have added the non repo-write permission [gitlab-ci-token](https://docs.gitlab.com/ee/ci/jobs/ci_job_token.html) to the origin url.
 


### PR DESCRIPTION
Suggested branch override with CI_COMMIT_BRANCH is not possible on merge request pipelines as it would be empty (source: https://docs.gitlab.com/ee/ci/variables/predefined_variables.html). Override with CI_COMMIT_REF_SLUG to fix.