### PR TITLE
set "VERSION_WITH_BRANCH" versionCreator as default

### DIFF
--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -265,7 +265,7 @@ This rule uses additional parameter `initialPreReleaseIfNotOnPrerelease`
 ## Decorating
 
 Decorating phase happens only when version is read (and deserialized).
-During this phase version will be decorated with branch name.
+During this phase, the version will be decorated with a branch name (default behavior).
 `axion-release-plugin` supports adding predefined named version creators
 (so don't be afraid to post pull request if you have something useful!).
 Decoration phase is conducted by *version creators*,
@@ -295,9 +295,23 @@ Per-branch version creators must be closures, there is no support for
 predefined creators. First match wins, but the order depends on
 collection type used (default for `[:]` is LinkedHashMap).
 
+#### versionWithBranch [default]
+
+    scmVersion {
+        versionCreator('versionWithBranch')
+    }
+
+This version creator appends branch name to version unless you are on
+*main*/*master* or *detached HEAD*:
+
+    decorate(version: '0.1.0', branch: 'master') == 0.1.0
+    decorate(version: '0.1.0', branch: 'my-special-branch') == 0.1.0-my-special-branch
+
+This is the default version creator since version 1.18.0 of the plugin. 
+
 #### simple
 
-This is the default version creator that does nothing:
+This version creator is no operation one:
 
     decorate(version: '0.1.0') == 0.1.0
 
@@ -309,18 +323,6 @@ It might be useful when you want some branches to do *nothing*:
             'release/.*': 'simple'
         ])
     }
-
-#### versionWithBranch
-
-    scmVersion {
-        versionCreator('versionWithBranch')
-    }
-
-This version creator appends branch name to version unless you are on
-*main*/*master* or *detached HEAD*:
-
-    decorate(version: '0.1.0', branch: 'master') == 0.1.0
-    decorate(version: '0.1.0', branch: 'my-special-branch') == 0.1.0-my-special-branch
 
 #### versionWithCommitHash
 

--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -255,8 +255,8 @@ it's set to `v/.+`):
 
 ### incrementPrerelease
 
-This rule uses additional parameter `initialPreReleaseIfNotOnPrerelease` (by default
-it's empty):
+This rule uses additional parameter `initialPreReleaseIfNotOnPrerelease`
+(by default it's empty):
 
     scmVersion {
         versionIncrementer('incrementPrerelease', [initialPreReleaseIfNotOnPrerelease: 'rc1'])
@@ -265,15 +265,15 @@ it's empty):
 ## Decorating
 
 Decorating phase happens only when version is read (and deserialized).
-During this phase version can be decorated with i.e. branch name.
-Default decorator does nothing. `axion-release-plugin` supports adding
-predefined named version creators (so don't be afraid to post pull
-request if you have something useful!). Decoration phase is conducted by
-*version creators*, you can configure it via `scmVersion.versionCreator`
+During this phase version will be decorated with branch name.
+`axion-release-plugin` supports adding predefined named version creators
+(so don't be afraid to post pull request if you have something useful!).
+Decoration phase is conducted by *version creators*,
+you can configure it via `scmVersion.versionCreator`
 method:
 
     scmVersion {
-        versionCreator('versionWithBranch')
+        versionCreator('versionWithCommitHash')
     }
 
 Or via `release.versionCreator` command line argument, which overrides

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreator.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/PredefinedVersionCreator.groovy
@@ -8,7 +8,7 @@ import java.util.function.BiFunction
 enum PredefinedVersionCreator {
 
     SIMPLE('simple', { String versionFromTag, ScmPosition position ->
-        return versionFromTag.toString()
+        return versionFromTag
     }),
 
     VERSION_WITH_BRANCH('versionWithBranch', { String versionFromTag, ScmPosition position ->

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -43,7 +43,7 @@ abstract class VersionConfig extends BaseExtension {
         getReleaseBranchPattern().convention(Pattern.compile('^' + defaultPrefix() + '(/.*)?$'))
         getSanitizeVersion().convention(true)
         getCreateReleaseCommit().convention(false)
-        getVersionCreator().convention(PredefinedVersionCreator.SIMPLE.versionCreator)
+        getVersionCreator().convention(PredefinedVersionCreator.VERSION_WITH_BRANCH.versionCreator)
         getVersionIncrementer().convention((VersionProperties.Incrementer) { VersionIncrementerContext context -> return context.currentVersion.incrementPatchVersion() })
         getSnapshotCreator().convention(PredefinedSnapshotCreator.SIMPLE.snapshotCreator)
         getReleaseCommitMessage().convention(PredefinedReleaseCommitMessageCreator.DEFAULT.commitMessageCreator)


### PR DESCRIPTION
There is a common problem with collaboration on code using this plugin.

When multiple feature branches are being developed (diverged from the same HEAD), by default, they will use a SIMPLE version creator that does not decorate versions in any way. So, both feature branches will generate the same version (v0.0.1-SNAPSHOT), leading to overriding snapshots during publication. That is prone to errors since Maven allows overriding SNAPSHOT versions.
 
This PR changes the default versionCreator to VERSION_WITH_BRANCH, which will append the branch name to version (v0.0.1-my-branch-name-SNAPSHOT) and will fallback to SIMPLE for detached HEAD checkouts (old behavior) 

People who explicitly need the SIMPLE version will need to update their configurations.

Draft release

![Screenshot 2024-07-05 at 10 11 03](https://github.com/allegro/axion-release-plugin/assets/2291045/f8c83761-f443-4fe2-9e8c-e061e9812d52)
