### PR TITLE
Read ref from GITHUB_HEAD_REF env variable if it's present

### DIFF
--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -297,6 +297,8 @@ collection type used (default for `[:]` is LinkedHashMap).
 
 #### versionWithBranch [default]
 
+This is the default version creator since version 1.18.0 of the plugin.
+
     scmVersion {
         versionCreator('versionWithBranch')
     }
@@ -307,7 +309,13 @@ This version creator appends branch name to version unless you are on
     decorate(version: '0.1.0', branch: 'master') == 0.1.0
     decorate(version: '0.1.0', branch: 'my-special-branch') == 0.1.0-my-special-branch
 
-This is the default version creator since version 1.18.0 of the plugin. 
+If your Gradle build is executed within workflow on GitHub Actions and that workflow is triggered by either
+`pull_request` or `pull_request_target` event, GitHub will not check out the source branch of the pull request but
+a custom reference `refs/pull/<pr_number>/merge` (known as "merge branch"). Consequently, the repository will be in
+detached-HEAD state.
+
+In that case, the branch name will be taken from `GITHUB_HEAD_REF` environment variable
+[provided by GitHub](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables).
 
 #### simple
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -1,55 +1,26 @@
 package pl.allegro.tech.build.axion.release.infrastructure.git;
 
-import org.eclipse.jgit.api.AddCommand;
-import org.eclipse.jgit.api.FetchCommand;
-import org.eclipse.jgit.api.Git;
-import org.eclipse.jgit.api.LogCommand;
-import org.eclipse.jgit.api.PushCommand;
-import org.eclipse.jgit.api.Status;
+import org.eclipse.jgit.api.*;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.NoHeadException;
 import org.eclipse.jgit.diff.DiffFormatter;
 import org.eclipse.jgit.errors.RepositoryNotFoundException;
-import org.eclipse.jgit.lib.AnyObjectId;
-import org.eclipse.jgit.lib.BranchTrackingStatus;
-import org.eclipse.jgit.lib.Config;
-import org.eclipse.jgit.lib.Constants;
-import org.eclipse.jgit.lib.ObjectId;
-import org.eclipse.jgit.lib.Ref;
-import org.eclipse.jgit.lib.Repository;
-import org.eclipse.jgit.lib.StoredConfig;
+import org.eclipse.jgit.lib.*;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevSort;
 import org.eclipse.jgit.revwalk.RevWalk;
-import org.eclipse.jgit.transport.PushResult;
-import org.eclipse.jgit.transport.RemoteConfig;
-import org.eclipse.jgit.transport.RemoteRefUpdate;
-import org.eclipse.jgit.transport.TagOpt;
-import org.eclipse.jgit.transport.URIish;
+import org.eclipse.jgit.transport.*;
 import org.eclipse.jgit.treewalk.filter.PathFilter;
 import org.eclipse.jgit.util.SystemReader;
 import org.eclipse.jgit.util.io.DisabledOutputStream;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmException;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository;
-import pl.allegro.tech.build.axion.release.domain.scm.ScmRepositoryUnavailableException;
-import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit;
+import pl.allegro.tech.build.axion.release.domain.scm.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.Optional;
+import java.util.*;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
@@ -333,37 +304,54 @@ public class GitRepository implements ScmRepository {
     }
 
     public ScmPosition currentPosition() {
+        String revision = getRevision();
+        String branchName = branchName();
+        boolean isClean = !checkUncommittedChanges();
+        return new ScmPosition(revision, branchName, isClean);
+    }
+
+    private String getRevision() {
         try {
             String revision = "";
             if (hasCommits()) {
                 ObjectId head = head();
                 revision = head.name();
             }
-
-            boolean isClean = !checkUncommittedChanges();
-
-            String branchName = branchName();
-            return new ScmPosition(revision, branchName, isClean);
+            return revision;
         } catch (IOException e) {
             throw new ScmException(e);
         }
     }
 
+    private String branchName() {
+        return branchNameFromEnvVariable().orElseGet(this::branchNameFromGit);
+    }
+
+    /**
+     * @return head ref or source branch of the pull request in a workflow run
+     */
+    private Optional<String> branchNameFromEnvVariable() {
+        return Optional.ofNullable(System.getenv("GITHUB_HEAD_REF"));
+    }
+
     /**
      * @return branch name or 'HEAD' when in detached state, unless it is overridden by 'overriddenBranchName'
      */
-    private String branchName() throws IOException {
-        // this returns HEAD as branch name when in detached state
-        Optional<Ref> ref = Optional.ofNullable(jgitRepository.getRepository().exactRef(Constants.HEAD));
-        String branchName = ref.map(r -> r.getTarget().getName())
-            .map(Repository::shortenRefName)
-            .orElse(null);
+    private String branchNameFromGit() {
+        try {
+            // this returns HEAD as branch name when in detached state
+            Optional<Ref> ref = Optional.ofNullable(jgitRepository.getRepository().exactRef(Constants.HEAD));
+            String branchName = ref.map(r -> r.getTarget().getName())
+                .map(Repository::shortenRefName)
+                .orElse(null);
 
-        if ("HEAD".equals(branchName) && properties.getOverriddenBranchName() != null && !properties.getOverriddenBranchName().isEmpty()) {
-            branchName = Repository.shortenRefName(properties.getOverriddenBranchName());
+            if ("HEAD".equals(branchName) && properties.getOverriddenBranchName() != null && !properties.getOverriddenBranchName().isEmpty()) {
+                branchName = Repository.shortenRefName(properties.getOverriddenBranchName());
+            }
+            return branchName;
+        } catch (IOException e) {
+            throw new ScmException(e);
         }
-
-        return branchName;
     }
 
     @Override

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/TestEnvironment.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/TestEnvironment.groovy
@@ -1,0 +1,39 @@
+package pl.allegro.tech.build.axion.release
+
+import org.spockframework.runtime.extension.IGlobalExtension
+
+import static java.util.stream.Collectors.toList
+
+class TestEnvironment implements IGlobalExtension {
+
+    private static Map<String, String> MUTABLE_ENV_MAP
+
+    @Override
+    void start() {
+        extractMutableMapFromSystemEnv()
+        clearGithubActionsVariables()
+    }
+
+    private static void extractMutableMapFromSystemEnv() {
+        def envMap = System.getenv()
+        def envMapClass = envMap.getClass()
+        def internalMapField = envMapClass.getDeclaredField("m")
+        internalMapField.setAccessible(true)
+        MUTABLE_ENV_MAP = (Map<String, String>) internalMapField.get(envMap)
+    }
+
+    private static void clearGithubActionsVariables() {
+        def keysToRemove = MUTABLE_ENV_MAP.keySet().stream()
+            .filter { variableName -> variableName.startsWith("GITHUB_") }
+            .collect(toList())
+        keysToRemove.forEach(MUTABLE_ENV_MAP::remove)
+    }
+
+    static void setEnvVariable(String name, String value) {
+        MUTABLE_ENV_MAP.put(name, value)
+    }
+
+    static void unsetEnvVariable(String name) {
+        MUTABLE_ENV_MAP.remove(name)
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -9,7 +9,7 @@ import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.transport.RemoteConfig
 import org.eclipse.jgit.transport.URIish
 import org.gradle.testfixtures.ProjectBuilder
-import pl.allegro.tech.build.axion.release.TestEnvironment
+import pl.allegro.tech.build.axion.release.util.WithEnvironment
 import pl.allegro.tech.build.axion.release.domain.scm.ScmException
 import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
@@ -629,11 +629,21 @@ class GitRepositoryTest extends Specification {
         position.revision == headSubDirAChanged
     }
 
+    @WithEnvironment([
+        "GITHUB_HEAD_REF=pull-request-branch"
+    ])
+    def "should get branch name from GITHUB_HEAD_REF if available"() {
+        when:
+        ScmPosition position = repository.currentPosition()
+
+        then:
+        position.branch == "pull-request-branch"
+    }
+
     private void commitFile(String subDir, String fileName) {
         String fileInA = "${subDir}/${fileName}"
         new File(repositoryDir, subDir).mkdirs()
         new File(repositoryDir, fileInA).createNewFile()
         repository.commit([fileInA], "Add file ${fileName} in ${subDir}")
     }
-
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -9,7 +9,14 @@ import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.transport.RemoteConfig
 import org.eclipse.jgit.transport.URIish
 import org.gradle.testfixtures.ProjectBuilder
-import pl.allegro.tech.build.axion.release.domain.scm.*
+import pl.allegro.tech.build.axion.release.TestEnvironment
+import pl.allegro.tech.build.axion.release.domain.scm.ScmException
+import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
+import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions
+import pl.allegro.tech.build.axion.release.domain.scm.ScmRepositoryUnavailableException
+import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
 import spock.lang.Specification
 
 import java.nio.file.Files
@@ -17,8 +24,8 @@ import java.nio.file.Path
 import java.util.regex.Pattern
 
 import static java.util.regex.Pattern.compile
-import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullPrefix
 import static pl.allegro.tech.build.axion.release.TagPrefixConf.defaultPrefix
+import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullPrefix
 import static pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilder.scmProperties
 
 class GitRepositoryTest extends Specification {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -630,56 +630,29 @@ class GitRepositoryTest extends Specification {
     }
 
     @WithEnvironment([
+        'GITHUB_ACTIONS=true',
         'GITHUB_EVENT_NAME=pull_request',
-        'GITHUB_HEAD_REF=pull-request-branch'
+        'GITHUB_HEAD_REF=pr-source-branch'
     ])
     def "should get branch name on Github Actions if pull_request triggered the workflow"() {
         when:
         ScmPosition position = repository.currentPosition()
 
         then:
-        position.branch == 'pull-request-branch'
+        position.branch == 'pr-source-branch'
     }
 
     @WithEnvironment([
+        'GITHUB_ACTIONS=true',
         'GITHUB_EVENT_NAME=pull_request_target',
-        'GITHUB_HEAD_REF=pull-request-branch'
+        'GITHUB_HEAD_REF=pr-source-branch'
     ])
     def "should get branch name on Github Actions if pull_request_target triggered the workflow"() {
         when:
             ScmPosition position = repository.currentPosition()
 
         then:
-            position.branch == 'pull-request-branch'
-    }
-
-    @WithEnvironment([
-        'GITHUB_EVENT_NAME=push',
-        'GITHUB_REF_TYPE=branch',
-        'GITHUB_REF_NAME=pushed-branch'
-    ])
-    def "should get branch name on Github Actions if branch push triggered the workflow"() {
-        when:
-            ScmPosition position = repository.currentPosition()
-
-        then:
-            position.branch == 'pushed-branch'
-    }
-
-    @WithEnvironment([
-        'GITHUB_EVENT_NAME=push',
-        'GITHUB_REF_TYPE=tag',
-        'GITHUB_REF_NAME=pushed-tag'
-    ])
-    def "should fall back to git on Github Actions if tag push triggered the workflow"() {
-        given:
-            rawRepository.checkout(branch: 'some-branch', createBranch: true)
-
-        when:
-            ScmPosition position = repository.currentPosition()
-
-        then:
-            position.branch == 'some-branch'
+            position.branch == 'pr-source-branch'
     }
 
     private void commitFile(String subDir, String fileName) {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/ClearGithubEnvVariablesExtension.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/ClearGithubEnvVariablesExtension.groovy
@@ -1,0 +1,16 @@
+package pl.allegro.tech.build.axion.release.util
+
+import org.spockframework.runtime.extension.IGlobalExtension
+
+import static java.util.stream.Collectors.toList
+
+class ClearGithubEnvVariablesExtension implements IGlobalExtension {
+
+    @Override
+    void start() {
+        def keysToRemove = TestEnvironment.getEnvVariableNames().stream()
+            .filter { variableName -> variableName.startsWith("GITHUB_") }
+            .collect(toList())
+        keysToRemove.forEach(TestEnvironment::unsetEnvVariable)
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/TestEnvironment.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/TestEnvironment.groovy
@@ -1,5 +1,10 @@
 package pl.allegro.tech.build.axion.release.util
 
+/**
+ * <p>Helper class for manipulating environment variables.</p>
+ *
+ * Credits to Kotest's <a href="https://github.com/kotest/kotest/blob/master/kotest-extensions/src/jvmMain/kotlin/io/kotest/extensions/system/SystemEnvironmentExtensions.kt#L26">withEnvironment</a>
+ */
 class TestEnvironment {
 
     private static Map<String, String> MUTABLE_ENV_MAP

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/TestEnvironment.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/TestEnvironment.groovy
@@ -1,17 +1,11 @@
 package pl.allegro.tech.build.axion.release.util
 
-import org.spockframework.runtime.extension.IGlobalExtension
-
-import static java.util.stream.Collectors.toList
-
-class TestEnvironment implements IGlobalExtension {
+class TestEnvironment {
 
     private static Map<String, String> MUTABLE_ENV_MAP
 
-    @Override
-    void start() {
+    static  {
         extractMutableMapFromSystemEnv()
-        clearGithubActionsVariables()
     }
 
     private static void extractMutableMapFromSystemEnv() {
@@ -22,18 +16,15 @@ class TestEnvironment implements IGlobalExtension {
         MUTABLE_ENV_MAP = (Map<String, String>) internalMapField.get(envMap)
     }
 
-    private static void clearGithubActionsVariables() {
-        def keysToRemove = MUTABLE_ENV_MAP.keySet().stream()
-            .filter { variableName -> variableName.startsWith("GITHUB_") }
-            .collect(toList())
-        keysToRemove.forEach(MUTABLE_ENV_MAP::remove)
-    }
-
     static void setEnvVariable(String name, String value) {
         MUTABLE_ENV_MAP.put(name, value)
     }
 
     static void unsetEnvVariable(String name) {
         MUTABLE_ENV_MAP.remove(name)
+    }
+
+    static Set<String> getEnvVariableNames() {
+        return MUTABLE_ENV_MAP.keySet()
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/TestEnvironment.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/TestEnvironment.groovy
@@ -1,4 +1,4 @@
-package pl.allegro.tech.build.axion.release
+package pl.allegro.tech.build.axion.release.util
 
 import org.spockframework.runtime.extension.IGlobalExtension
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironment.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironment.groovy
@@ -1,0 +1,17 @@
+package pl.allegro.tech.build.axion.release.util
+
+
+import org.spockframework.runtime.extension.ExtensionAnnotation
+
+import java.lang.annotation.ElementType
+import java.lang.annotation.Retention
+import java.lang.annotation.RetentionPolicy
+import java.lang.annotation.Target
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+@ExtensionAnnotation(WithEnvironmentExtension.class)
+@interface WithEnvironment {
+
+    String[] value()
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironmentExtension.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironmentExtension.groovy
@@ -13,12 +13,11 @@ class WithEnvironmentExtension implements IAnnotationDrivenExtension<WithEnviron
     @Override
     void visitFeatureAnnotation(WithEnvironment annotation, FeatureInfo feature) {
         feature.getFeatureMethod().addInterceptor { invocation ->
-            def envVarDefinitions = annotation.value().toList().stream()
-                .map {
-                    def array = it.split("=")
-                    Pair.of(array[0], array[1])
-                }
+            List<Pair<String, String>> envVarDefinitions = annotation.value().toList().stream()
+                .map { it.split("=") }
+                .map { Pair.of(it[0], it[1]) }
                 .collect(toList())
+
             envVarDefinitions.forEach { setEnvVariable(it.first(), it.second()) }
             invocation.proceed()
             envVarDefinitions.forEach { unsetEnvVariable(it.first()) }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironmentExtension.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironmentExtension.groovy
@@ -1,0 +1,27 @@
+package pl.allegro.tech.build.axion.release.util
+
+import org.spockframework.runtime.extension.IAnnotationDrivenExtension
+import org.spockframework.runtime.model.FeatureInfo
+import org.spockframework.util.Pair
+
+import static java.util.stream.Collectors.toList
+import static TestEnvironment.setEnvVariable
+import static TestEnvironment.unsetEnvVariable
+
+class WithEnvironmentExtension implements IAnnotationDrivenExtension<WithEnvironment> {
+
+    @Override
+    void visitFeatureAnnotation(WithEnvironment annotation, FeatureInfo feature) {
+        feature.getFeatureMethod().addInterceptor { invocation ->
+            def envVarDefinitions = annotation.value().toList().stream()
+                .map {
+                    def array = it.split("=")
+                    Pair.of(array[0], array[1])
+                }
+                .collect(toList())
+            envVarDefinitions.forEach { setEnvVariable(it.first(), it.second()) }
+            invocation.proceed()
+            envVarDefinitions.forEach { unsetEnvVariable(it.first()) }
+        }
+    }
+}

--- a/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,1 +1,1 @@
-pl.allegro.tech.build.axion.release.TestEnvironment
+pl.allegro.tech.build.axion.release.util.TestEnvironment

--- a/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,1 +1,1 @@
-pl.allegro.tech.build.axion.release.util.TestEnvironment
+pl.allegro.tech.build.axion.release.util.ClearGithubEnvVariablesExtension

--- a/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
+++ b/src/test/resources/META-INF/services/org.spockframework.runtime.extension.IGlobalExtension
@@ -1,0 +1,1 @@
+pl.allegro.tech.build.axion.release.TestEnvironment


### PR DESCRIPTION
When using `axion-release` together with [actions/checkout](https://github.com/actions/checkout), we needed to add the special configuration:
```
steps:
  - uses: actions/checkout@v4
    with:
      ref: ${{ github.head_ref }}
```
Otherwise, the action checks out repository in a detached-HEAD state and `axion-release` is not able to get the branch name.

Even though the branch ref is not checked out by default, Github provides the `GITHUB_HEAD_REF` which contains branch name that triggered the workflow. After this PR, `axion-release` will read this variable if available or fall back to git to preserve old behavior.