### PR TITLE
Fix for GITHUB_HEAD_REF having empty value

### DIFF
--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -343,7 +343,10 @@ public class GitRepository implements ScmRepository {
      */
     private Optional<String> branchNameFromGithubEnvVariable() {
         if (env("GITHUB_ACTIONS").isPresent()) {
-            return env("GITHUB_HEAD_REF");
+            return env("GITHUB_HEAD_REF")
+                // GitHub violates its own documentation and sets this variable always. For pull_request and
+                // pull_request_target it contains actual value, for every other event it's just empty string
+                .filter(it -> !it.isBlank());
         }
         return Optional.empty();
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -631,7 +631,6 @@ class GitRepositoryTest extends Specification {
 
     @WithEnvironment([
         'GITHUB_ACTIONS=true',
-        'GITHUB_EVENT_NAME=pull_request',
         'GITHUB_HEAD_REF=pr-source-branch'
     ])
     def "should get branch name on Github Actions if pull_request triggered the workflow"() {
@@ -644,15 +643,14 @@ class GitRepositoryTest extends Specification {
 
     @WithEnvironment([
         'GITHUB_ACTIONS=true',
-        'GITHUB_EVENT_NAME=pull_request_target',
-        'GITHUB_HEAD_REF=pr-source-branch'
+        'GITHUB_HEAD_REF='
     ])
     def "should get branch name on Github Actions if pull_request_target triggered the workflow"() {
         when:
             ScmPosition position = repository.currentPosition()
 
         then:
-            position.branch == 'pr-source-branch'
+            position.branch == 'main'
     }
 
     private void commitFile(String subDir, String fileName) {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -30,7 +30,6 @@ import static pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilde
 
 class GitRepositoryTest extends Specification {
 
-    public static final String MASTER_BRANCH = "master"
     File repositoryDir
 
     File remoteRepositoryDir
@@ -43,6 +42,8 @@ class GitRepositoryTest extends Specification {
 
     GitRepository repository
 
+    String defaultBranch;
+
     void setup() {
         remoteRepositoryDir = File.createTempDir('axion-release', 'tmp')
         Map remoteRepositories = GitProjectBuilder.gitProject(remoteRepositoryDir).withInitialCommit().build()
@@ -54,6 +55,9 @@ class GitRepositoryTest extends Specification {
 
         rawRepository = repositories[Grgit]
         repository = repositories[GitRepository]
+
+        assert rawRepository.branch.current().name == remoteRawRepository.branch.current().name
+        defaultBranch = rawRepository.branch.current().name
     }
 
     def "should throw unavailable exception when initializing in unexisitng repository"() {
@@ -592,7 +596,7 @@ class GitRepositoryTest extends Specification {
         git.checkout().setName(secondBranchName).call()
         commitFile('second/aa', 'foo')
         commitFile('b/ba', 'bar')
-        git.checkout().setName(MASTER_BRANCH).call()
+        git.checkout().setName(defaultBranch).call()
         git.merge().include(git.repository.resolve(secondBranchName)).setCommit(true).setMessage("unintresting").setFastForward(MergeCommand.FastForwardMode.NO_FF).call()
 
         commitFile('after/aa', 'after')
@@ -645,12 +649,12 @@ class GitRepositoryTest extends Specification {
         'GITHUB_ACTIONS=true',
         'GITHUB_HEAD_REF='
     ])
-    def "should get branch name on Github Actions if pull_request_target triggered the workflow"() {
+    def "should ignore GITHUB_HEAD_REF variable if it has empty value"() {
         when:
             ScmPosition position = repository.currentPosition()
 
         then:
-            position.branch == 'main'
+            position.branch == defaultBranch
     }
 
     private void commitFile(String subDir, String fileName) {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironmentExtension.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/util/WithEnvironmentExtension.groovy
@@ -15,7 +15,14 @@ class WithEnvironmentExtension implements IAnnotationDrivenExtension<WithEnviron
         feature.getFeatureMethod().addInterceptor { invocation ->
             List<Pair<String, String>> envVarDefinitions = annotation.value().toList().stream()
                 .map { it.split("=") }
-                .map { Pair.of(it[0], it[1]) }
+                .map { parts ->
+                    switch (parts.length) {
+                        case 2: return Pair.of(parts[0], parts[1])
+                        case 1: return Pair.of(parts[0], "")
+                        default: return null
+                    }
+                }
+                .filter { it != null }
                 .collect(toList())
 
             envVarDefinitions.forEach { setEnvVariable(it.first(), it.second()) }


### PR DESCRIPTION
GitHub violates its own documentation and sets the `GITHUB_HEAD_REF` variable always. For `pull_request` and
`pull_request_target` it contains actual value, for every other event it's just empty string