### PR TITLE
Implement support for fallback tag prefixes

### DIFF
--- a/docs/configuration/version.md
+++ b/docs/configuration/version.md
@@ -33,6 +33,17 @@ calculating current version. Prefix can be set using
 
 Default prefix is `v`.
 
+In case a tag does not match the main prefix, fallback prefixes will be examined. You can use fallback prefixes to migrate from one prefix to another. For example, if you use prefix `my-service-` but want to migrate to prefix `v`, you can configure it like that:
+
+    scmVersion {
+        tag {
+            prefix.set("v")
+            fallbackPrefixes.set(listOf("my-service-"))
+        }
+    }
+
+Axion will use fallback prefixes to calculate latest version, but the next release tag will be created using the main prefix.
+
 There is also an option to set prefix per-branch (i.e. to use different
 version prefix on `legacy-` branches):
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializationConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializationConfig.groovy
@@ -1,5 +1,6 @@
 package pl.allegro.tech.build.axion.release.domain
 
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -15,6 +16,7 @@ abstract class TagNameSerializationConfig extends BaseExtension {
         deserialize.convention(TagNameSerializer.DEFAULT.deserializer)
         initialVersion.convention(defaultInitialVersion())
         prefix.convention(TagPrefixConf.defaultPrefix())
+        fallbackPrefixes.convention(Collections.emptyList())
         versionSeparator.convention(TagPrefixConf.defaultSeparator())
     }
 
@@ -23,6 +25,9 @@ abstract class TagNameSerializationConfig extends BaseExtension {
 
     @Input
     abstract MapProperty<String, String> getBranchPrefix()
+
+    @Input
+    abstract ListProperty<String> getFallbackPrefixes()
 
     @Input
     abstract Property<String> getVersionSeparator()

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializer.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializer.groovy
@@ -6,15 +6,19 @@ import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 enum TagNameSerializer {
 
     DEFAULT('default',
-            { TagProperties rules, String version ->
-                return rules.prefix ? rules.prefix + rules.versionSeparator + version : version
-            },
-            { TagProperties rules, ScmPosition position, String tagName ->
-                if (rules.prefix.isEmpty()) {
-                    return tagName
-                }
-                return tagName.substring(rules.prefix.length() + rules.versionSeparator.length())
+        { TagProperties rules, String version ->
+            return rules.prefix ? rules.prefix + rules.versionSeparator + version : version
+        },
+        { TagProperties rules, ScmPosition position, String tagName ->
+            if (rules.prefix.isEmpty()) {
+                return tagName
             }
+            for (String prefix : rules.allPrefixes) {
+                if (tagName.matches("^" + prefix + rules.versionSeparator + ".*")) {
+                    return tagName.substring(prefix.length() + rules.versionSeparator.length())
+                }
+            }
+        }
     )
 
     private final String type

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/DummyRepository.groovy
@@ -69,19 +69,19 @@ class DummyRepository implements ScmRepository {
     }
 
     @Override
-    TagsOnCommit latestTags(Pattern pattern) {
+    TagsOnCommit latestTags(List<Pattern> patterns) {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
         return new TagsOnCommit(null, [])
     }
 
     @Override
-    TagsOnCommit latestTags(Pattern pattern, String sinceCommit) {
+    TagsOnCommit latestTags(List<Pattern> patterns, String sinceCommit) {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
         return new TagsOnCommit(null, [])
     }
 
     @Override
-    List<TagsOnCommit> taggedCommits(Pattern pattern) {
+    List<TagsOnCommit> taggedCommits(List<Pattern> patterns) {
         logger.quiet("Could not resolve current position on uninitialized repository, returning default")
         return [new TagsOnCommit(null, [])]
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/NoOpRepository.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/NoOpRepository.groovy
@@ -64,22 +64,22 @@ class NoOpRepository implements ScmRepository {
     }
 
     @Override
-    TagsOnCommit latestTags(Pattern pattern) {
-        TagsOnCommit tags = delegateRepository.latestTags(pattern)
+    TagsOnCommit latestTags(List<Pattern> patterns) {
+        TagsOnCommit tags = delegateRepository.latestTags(patterns)
         log("Latest tags: ${tags.tags}")
         return tags
     }
 
     @Override
-    TagsOnCommit latestTags(Pattern pattern, String sinceCommit) {
-        TagsOnCommit tags = delegateRepository.latestTags(pattern, sinceCommit)
+    TagsOnCommit latestTags(List<Pattern> patterns, String sinceCommit) {
+        TagsOnCommit tags = delegateRepository.latestTags(patterns, sinceCommit)
         log("Latest tags: ${tags.tags}")
         return tags
     }
 
     @Override
-    List<TagsOnCommit> taggedCommits(Pattern pattern) {
-        return delegateRepository.taggedCommits(pattern)
+    List<TagsOnCommit> taggedCommits(List<Pattern> patterns) {
+        return delegateRepository.taggedCommits(patterns)
     }
 
     @Override

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/TagPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/TagPropertiesFactory.groovy
@@ -10,6 +10,7 @@ class TagPropertiesFactory {
     static TagProperties create(TagNameSerializationConfig config, String currentBranch) {
         return new TagProperties(
             findPrefix(config, currentBranch),
+            config.fallbackPrefixes.get(),
             config.versionSeparator.get(),
             config.serialize.get(),
             config.deserialize.get(),

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/TagProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/properties/TagProperties.java
@@ -2,6 +2,11 @@ package pl.allegro.tech.build.axion.release.domain.properties;
 
 import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
 
+import java.util.List;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
 public class TagProperties {
 
     public interface Serializer {
@@ -17,6 +22,7 @@ public class TagProperties {
     }
 
     private final String prefix;
+    private final List<String> fallbackPrefixes;
     private final String versionSeparator;
     private final Serializer serialize;
     private final Deserializer deserialize;
@@ -24,12 +30,14 @@ public class TagProperties {
 
     public TagProperties(
         String prefix,
+        List<String> fallbackPrefixes,
         String versionSeparator,
         Serializer serialize,
         Deserializer deserialize,
         InitialVersionSupplier initialVersion
     ) {
         this.prefix = prefix;
+        this.fallbackPrefixes = fallbackPrefixes;
         this.versionSeparator = versionSeparator;
         this.serialize = serialize;
         this.deserialize = deserialize;
@@ -38,6 +46,17 @@ public class TagProperties {
 
     public final String getPrefix() {
         return prefix;
+    }
+
+    public final List<String> getFallbackPrefixes() {
+        return fallbackPrefixes;
+    }
+
+    public final List<String> getAllPrefixes() {
+        return Stream.concat(
+            Stream.of(prefix), // main prefix takes precedence
+            fallbackPrefixes.stream()
+        ).collect(toList());
     }
 
     public final String getVersionSeparator() {

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmRepository.java
@@ -24,11 +24,11 @@ public interface ScmRepository {
 
     Boolean isIdenticalForPath(String path, String latestChangeRevision, String tagCommitRevision);
 
-    TagsOnCommit latestTags(Pattern pattern);
+    TagsOnCommit latestTags(List<Pattern> patterns);
 
-    TagsOnCommit latestTags(Pattern pattern, String sinceCommit);
+    TagsOnCommit latestTags(List<Pattern> patterns, String sinceCommit);
 
-    List<TagsOnCommit> taggedCommits(Pattern pattern);
+    List<TagsOnCommit> taggedCommits(List<Pattern> patterns);
 
     boolean remoteAttached(String remoteName);
 

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/TaggedCommits.java
@@ -18,20 +18,20 @@ public class TaggedCommits {
         return new TaggedCommits(latestTagPosition, taggedCommits);
     }
 
-    public static TaggedCommits fromLatestCommit(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition) {
-        TagsOnCommit latestTags = repository.latestTags(tagPattern);
+    public static TaggedCommits fromLatestCommit(ScmRepository repository, List<Pattern> relaseTagPatterns, ScmPosition latestTagPosition) {
+        TagsOnCommit latestTags = repository.latestTags(relaseTagPatterns);
         return new TaggedCommits(latestTagPosition, Arrays.asList(latestTags));
     }
 
-    public static TaggedCommits fromAllCommits(ScmRepository repository, Pattern tagPattern, ScmPosition latestTagPosition) {
-        List<TagsOnCommit> taggedCommits = repository.taggedCommits(tagPattern);
+    public static TaggedCommits fromAllCommits(ScmRepository repository, List<Pattern> releaseTagPatterns, ScmPosition latestTagPosition) {
+        List<TagsOnCommit> taggedCommits = repository.taggedCommits(releaseTagPatterns);
         return new TaggedCommits(latestTagPosition, taggedCommits);
     }
 
-    public static TaggedCommits fromLatestCommitBeforeNextVersion(ScmRepository repository, Pattern releaseTagPattern, Pattern nextVersionTagPattern, ScmPosition latestTagPosition) {
-        TagsOnCommit previousTags = repository.latestTags(releaseTagPattern);
+    public static TaggedCommits fromLatestCommitBeforeNextVersion(ScmRepository repository, List<Pattern> releaseTagPatterns, Pattern nextVersionTagPattern, ScmPosition latestTagPosition) {
+        TagsOnCommit previousTags = repository.latestTags(releaseTagPatterns);
         while (previousTags.hasOnlyMatching(nextVersionTagPattern)) {
-            previousTags = repository.latestTags(releaseTagPattern, previousTags.getCommitId());
+            previousTags = repository.latestTags(releaseTagPatterns, previousTags.getCommitId());
         }
         return new TaggedCommits(latestTagPosition, Arrays.asList(previousTags));
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/NextVersionMarkerTest.groovy
@@ -44,7 +44,7 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
         nextVersionMarker.markNextVersion(rules, tagRules, config)
 
         then:
-        repository.latestTags(~/.*/).tags == [fullPrefix()  + '2.0.0-alpha']
+        repository.latestTags(List.of(~/.*/)).tags == [fullPrefix()  + '2.0.0-alpha']
     }
 
     def "should create next version with default incrementer"() {
@@ -56,7 +56,7 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
         nextVersionMarker.markNextVersion(rules, tagRules, config)
 
         then:
-        repository.latestTags(~/.*/).tags == [fullPrefix() + '0.1.1-alpha']
+        repository.latestTags(List.of(~/.*/)).tags == [fullPrefix() + '0.1.1-alpha']
     }
 
     def "should create next version with major incrementer"() {
@@ -70,6 +70,6 @@ class NextVersionMarkerTest extends RepositoryBasedTest {
         nextVersionMarker.markNextVersion(rules, tagRules, config)
 
         then:
-        repository.latestTags(~/.*/).tags == [fullPrefix() + '1.0.0-alpha']
+        repository.latestTags(List.of(~/.*/)).tags == [fullPrefix() + '1.0.0-alpha']
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializerTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/TagNameSerializerTest.groovy
@@ -1,21 +1,25 @@
 package pl.allegro.tech.build.axion.release.domain
 
-import pl.allegro.tech.build.axion.release.TagPrefixConf
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
 import spock.lang.Specification
 
-import static pl.allegro.tech.build.axion.release.TagPrefixConf.*
+import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullPrefix
 import static pl.allegro.tech.build.axion.release.domain.properties.TagPropertiesBuilder.tagProperties
 import static pl.allegro.tech.build.axion.release.domain.scm.ScmPositionBuilder.scmPosition
 
 class TagNameSerializerTest extends Specification {
+
+    static final TagProperties.Serializer DEFAULT_SERIALIZER = TagNameSerializer.DEFAULT.serializer
+    static final TagProperties.Deserializer DEFAULT_DESERIALIZER = TagNameSerializer.DEFAULT.deserializer
+    static final ScmPosition MASTER = scmPosition('master')
 
     def "default serializer should return concatenated prefix, version separator and version by default"() {
         given:
         TagProperties properties = tagProperties().build()
 
         expect:
-        TagNameSerializer.DEFAULT.serializer.apply(properties, '0.1.0') == fullPrefix() + '0.1.0'
+        DEFAULT_SERIALIZER.apply(properties, '0.1.0') == fullPrefix() + '0.1.0'
     }
 
     def "default deserializer should read version by stripping off prefix and version separator"() {
@@ -23,7 +27,7 @@ class TagNameSerializerTest extends Specification {
         TagProperties properties = tagProperties().build()
 
         expect:
-        TagNameSerializer.DEFAULT.deserializer.apply(properties, scmPosition('master'), fullPrefix() + '0.1.0') == '0.1.0'
+        DEFAULT_DESERIALIZER.apply(properties, MASTER, fullPrefix() + '0.1.0') == '0.1.0'
     }
 
     def "default serializer should use empty version separator when prefix is empty"() {
@@ -31,7 +35,7 @@ class TagNameSerializerTest extends Specification {
         TagProperties properties = tagProperties().withPrefix('').build()
 
         expect:
-        TagNameSerializer.DEFAULT.serializer.apply(properties, '0.1.0') == '0.1.0'
+        DEFAULT_SERIALIZER.apply(properties, '0.1.0') == '0.1.0'
     }
 
     def "default deserializer should use empty version separator when prefix is empty"() {
@@ -39,6 +43,62 @@ class TagNameSerializerTest extends Specification {
         TagProperties properties = tagProperties().withPrefix('').build()
 
         expect:
-        TagNameSerializer.DEFAULT.deserializer.apply(properties, scmPosition('master'), '0.1.0') == '0.1.0'
+        DEFAULT_DESERIALIZER.apply(properties, MASTER, '0.1.0') == '0.1.0'
+    }
+
+    def "default deserializer should use fallback prefix in case tag doesn't match main prefix"() {
+        given:
+        TagProperties properties = tagProperties()
+            .withPrefix("v")
+            .withFallbackPrefixes(List.of('example-service-'))
+            .build()
+
+        when:
+        String deserializedVersion = DEFAULT_DESERIALIZER.apply(properties, MASTER, 'example-service-0.1.0')
+
+        then:
+        deserializedVersion == '0.1.0'
+    }
+
+    def "default deserializer should use second fallback prefix in case tag doesn't match main and first fallback"() {
+        given:
+        TagProperties properties = tagProperties()
+            .withPrefix("v")
+            .withFallbackPrefixes(List.of('example-service-', 'release-'))
+            .build()
+
+        when:
+        String deserializedVersion = DEFAULT_DESERIALIZER.apply(properties, MASTER, 'release-0.1.0')
+
+        then:
+        deserializedVersion == '0.1.0'
+    }
+
+    def "default deserializer should give main prefix precedence over fallback prefixes"() {
+        given:
+        TagProperties properties = tagProperties()
+            .withPrefix("abc")
+            .withFallbackPrefixes(List.of('a', 'ab'))
+            .build()
+
+        when:
+        String deserializedVersion = DEFAULT_DESERIALIZER.apply(properties, MASTER, 'abc0.1.0')
+
+        then:
+        deserializedVersion == '0.1.0'
+    }
+
+    def "default deserializer should check whether tag matches prefix and separator"() {
+        given:
+        TagProperties properties = tagProperties()
+            .withPrefix("v")
+            .withSeparator("-")
+            .build()
+
+        when:
+        String deserializedVersion = DEFAULT_DESERIALIZER.apply(properties, MASTER, 'v0.1.0')
+
+        then:
+        deserializedVersion == null
     }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/properties/TagPropertiesBuilder.groovy
@@ -6,6 +6,8 @@ import pl.allegro.tech.build.axion.release.domain.TagNameSerializer
 class TagPropertiesBuilder {
 
     private String prefix = TagPrefixConf.defaultPrefix()
+    private List<String> fallbackPrefixes = Collections.emptyList()
+    private String separator = TagPrefixConf.defaultSeparator()
 
     private TagPropertiesBuilder() {
     }
@@ -17,7 +19,8 @@ class TagPropertiesBuilder {
     TagProperties build() {
         return new TagProperties(
             prefix,
-            TagPrefixConf.defaultSeparator(),
+            fallbackPrefixes,
+            separator,
             TagNameSerializer.DEFAULT.serializer,
             TagNameSerializer.DEFAULT.deserializer,
             { r, p -> '0.1.0' }
@@ -29,4 +32,13 @@ class TagPropertiesBuilder {
         return this
     }
 
+    TagPropertiesBuilder withFallbackPrefixes(List<String> fallbackPrefixes) {
+        this.fallbackPrefixes = fallbackPrefixes
+        return this
+    }
+
+    TagPropertiesBuilder withSeparator(String separator) {
+        this.separator = separator
+        return this
+    }
 }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -84,7 +84,7 @@ class GitRepositoryTest extends Specification {
 
         when:
         lightweightTagRepository.tag(fullPrefix() + '2')
-        TagsOnCommit tags = lightweightTagRepository.latestTags(compile('^' + defaultPrefix() + '.*'))
+        TagsOnCommit tags = lightweightTagRepository.latestTags(List.of(compile('^' + defaultPrefix() + '.*')))
 
         then:
         tags.tags == [fullPrefix() + '1', fullPrefix() + '2']
@@ -145,7 +145,7 @@ class GitRepositoryTest extends Specification {
         repository.commit(['*'], "commit after release")
 
         when:
-        TagsOnCommit tags = repository.latestTags(Pattern.compile('^' + defaultPrefix() + '.*'))
+        TagsOnCommit tags = repository.latestTags(List.of(Pattern.compile('^' + defaultPrefix() + '.*')))
 
         then:
         tags.tags == [fullPrefix() + '1']
@@ -156,7 +156,7 @@ class GitRepositoryTest extends Specification {
         GitRepository commitlessRepository = GitProjectBuilder.gitProject(File.createTempDir('axion-release', 'tmp')).build()[GitRepository]
 
         when:
-        TagsOnCommit tags = commitlessRepository.latestTags(Pattern.compile('^' + defaultPrefix() + '.*'))
+        TagsOnCommit tags = commitlessRepository.latestTags(List.of(compile('^' + defaultPrefix() + '.*')))
 
         then:
         tags.tags == []
@@ -167,7 +167,7 @@ class GitRepositoryTest extends Specification {
         repository.tag(fullPrefix() + '1')
 
         when:
-        TagsOnCommit tags = repository.latestTags(Pattern.compile('' + defaultPrefix() + '.*'))
+        TagsOnCommit tags = repository.latestTags(List.of(Pattern.compile('' + defaultPrefix() + '.*')))
 
         then:
         tags.tags == [fullPrefix() + '1']
@@ -184,7 +184,7 @@ class GitRepositoryTest extends Specification {
         repository.commit(['*'], "bugfix after " + fullPrefix() + "1")
 
         when:
-        TagsOnCommit tags = repository.latestTags(Pattern.compile("^" + defaultPrefix() + ".*"))
+        TagsOnCommit tags = repository.latestTags(List.of(Pattern.compile("^" + defaultPrefix() + ".*")))
 
         then:
         tags.tags == [fullPrefix() + '1']
@@ -205,7 +205,7 @@ class GitRepositoryTest extends Specification {
         repository.commit(['*'], "commit after " + fullPrefix() + "3")
 
         when:
-        List<TagsOnCommit> allTaggedCommits = repository.taggedCommits(Pattern.compile('^' + defaultPrefix() + '.*'))
+        List<TagsOnCommit> allTaggedCommits = repository.taggedCommits(List.of(compile('^' + defaultPrefix() + '.*')))
 
         then:
         allTaggedCommits.collect { c -> c.tags[0] } == [fullPrefix() +'3',fullPrefix() + '4', fullPrefix() + '2', fullPrefix() +'1']
@@ -218,7 +218,7 @@ class GitRepositoryTest extends Specification {
         repository.tag('otherTag')
 
         when:
-        TagsOnCommit tags = repository.latestTags(Pattern.compile('^' + defaultPrefix() + '.*'))
+        TagsOnCommit tags = repository.latestTags(List.of(Pattern.compile('^' + defaultPrefix() + '.*')))
 
         then:
         tags.tags == [fullPrefix() + '1']
@@ -230,10 +230,10 @@ class GitRepositoryTest extends Specification {
         repository.commit(['*'], 'some commit')
         repository.tag('tag-to-skip')
 
-        String latestCommitId = repository.latestTags(~'^tag.*').commitId
+        String latestCommitId = repository.latestTags(List.of(~'^tag.*')).commitId
 
         when:
-        TagsOnCommit tags = repository.latestTags(~'^tag.*', latestCommitId)
+        TagsOnCommit tags = repository.latestTags(List.of(~'^tag.*'), latestCommitId)
 
         then:
         tags.tags == ['tag-to-find']
@@ -245,7 +245,7 @@ class GitRepositoryTest extends Specification {
         repository.tag(fullPrefix() + '2')
 
         when:
-        TagsOnCommit tags = repository.latestTags(Pattern.compile('^' + defaultPrefix() + '.*'))
+        TagsOnCommit tags = repository.latestTags(List.of(compile('^' + defaultPrefix() + '.*')))
 
         then:
         tags.tags == [fullPrefix() + '1', fullPrefix() + '2']
@@ -451,14 +451,14 @@ class GitRepositoryTest extends Specification {
     def "should remove tag"() {
         given:
         repository.tag(fullPrefix() +"1")
-        int intermediateSize = repository.taggedCommits(~/.*/).size()
+        int intermediateSize = repository.taggedCommits(List.of(~/.*/)).size()
 
         when:
         repository.dropTag(fullPrefix() +"1")
 
         then:
         intermediateSize == 1
-        repository.taggedCommits(~/.*/).isEmpty()
+        repository.taggedCommits(List.of(~/.*/)).isEmpty()
     }
 
     def "should pass ahead of remote check when in sync with remote"() {
@@ -669,7 +669,7 @@ class GitRepositoryTest extends Specification {
         GitRepository repository = repositories[GitRepository]
 
         when:
-        TagsOnCommit tags = repository.latestTags(compile('^' + defaultPrefix() + '.*'))
+        TagsOnCommit tags = repository.latestTags(List.of(compile('^' + defaultPrefix() + '.*')))
 
         then:
         tags.tags == [fullPrefix() + '1']
@@ -687,7 +687,7 @@ class GitRepositoryTest extends Specification {
             GitRepository repository = repositories[GitRepository]
 
         when:
-            TagsOnCommit tags = repository.latestTags(compile('^' + defaultPrefix() + '.*'))
+            TagsOnCommit tags = repository.latestTags(List.of(compile('^' + defaultPrefix() + '.*')))
 
         then:
             tags.tags.isEmpty()

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/NoOpRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/NoOpRepositoryTest.groovy
@@ -43,7 +43,7 @@ class NoOpRepositoryTest extends Specification {
         scm.latestTags(_) >> expected
 
         when:
-        TagsOnCommit current = dryRepository.latestTags(~/^release.*/)
+        TagsOnCommit current = dryRepository.latestTags(List.of(~/^release.*/))
 
         then:
         current == expected


### PR DESCRIPTION
### Usage

```kotlin
scmVersion {
    tags {
        prefix = "v"
        fallbackPrefixes = listOf("${rootProject.name}-")
    }
}
```

### How it works

We can think of `fallbackPrefixes` as "read-only prefixes". They are used as fallbacks when deserializing version from tags, but only the "main" prefix will be serialized. Even during deserialization, the "main" prefix takes precedence over the fallback prefixes.