### PR TITLE
fix VerifyReleaseTask with isReleaseOnlyOnReleaseBranches compability

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseBranchesConfiguration.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleaseBranchesConfiguration.groovy
@@ -15,7 +15,7 @@ class ReleaseBranchesConfiguration {
         this.releaseBranchNames = releaseBranchNames
     }
 
-    boolean shouldRelease() {
+    boolean shouldSkipRelease() {
         return releaseOnlyOnReleaseBranches && !releaseBranchNames.contains(currentBranch)
     }
 

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseTask.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/VerifyReleaseTask.groovy
@@ -17,6 +17,22 @@ abstract class VerifyReleaseTask extends BaseAxionTask {
     void verify() {
         VersionResolutionContext context = resolutionContext()
 
+        ReleaseBranchesConfiguration releaseBranchesConfiguration = new ReleaseBranchesConfiguration(
+            context.scmService().isReleaseOnlyOnReleaseBranches(),
+            context.repository().currentPosition().getBranch(),
+            context.scmService().getReleaseBranchNames()
+        )
+
+        if (releaseBranchesConfiguration.shouldSkipRelease()) {
+            String message = String.format(
+                "Release step skipped since 'releaseOnlyOnReleaseBranches' option is set, and '%s' was not in 'releaseBranchNames' list [%s]",
+                releaseBranchesConfiguration.getCurrentBranch(),
+                String.join(",", releaseBranchesConfiguration.getReleaseBranchNames())
+            )
+            logger.quiet(message)
+            return
+        }
+
         ScmRepository repository = context.repository()
         ScmChangesPrinter changesPrinter = context.changesPrinter()
         LocalOnlyResolver localOnlyResolver = context.localOnlyResolver()

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/Releaser.java
@@ -26,7 +26,7 @@ public class Releaser {
     }
 
     public Optional<String> release(Properties properties, ReleaseBranchesConfiguration releaseBranchesConfiguration) {
-        if (releaseBranchesConfiguration.shouldRelease()) {
+        if (releaseBranchesConfiguration.shouldSkipRelease()) {
             String message = String.format(
                 "Release step skipped since 'releaseOnlyOnReleaseBranches' option is set, and '%s' was not in 'releaseBranchNames' list [%s]",
                 releaseBranchesConfiguration.getCurrentBranch(),


### PR DESCRIPTION
When `isReleaseOnlyOnReleaseBranches` is iused, verify task should be skipped