### PR TITLE
Fix ConcurrentModificationException in SnapshotDependenciesChecker

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/SnapshotDependenciesChecker.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/SnapshotDependenciesChecker.groovy
@@ -10,19 +10,18 @@ class SnapshotDependenciesChecker {
     Collection<String> snapshotVersions(Project project) {
         Collection<String> projectVersions = project.getRootProject().getAllprojects()
             .collect { toFullVersion(it) }
-        Collection<String> allDependenciesVersions = []
-        for (final Project proj in project.getRootProject().getAllprojects()) {
-            for (Configuration config : proj.getConfigurations()) {
-                Collection<String> versions = config.getAllDependencies()
-                    .findAll { isSnapshot(it) }
-                    .collect { toFullVersion(it) }
-                +config.getAllDependencyConstraints()
-                    .findAll { isSnapshot(it) }
-                    .collect { toFullVersion(it) }
-                allDependenciesVersions.addAll(versions)
-            }
+        Collection<Configuration> configurations = project.getRootProject().getAllprojects()
+            .collect { it.getConfigurations() }.flatten() as Collection<Configuration>
+        Collection<String> allDependenciesVersions = new HashSet<>()
+        for (Configuration config : configurations) {
+            Collection<String> versions = config.getAllDependencies()
+                .findAll { isSnapshot(it) }
+                .collect { toFullVersion(it) }
+            +config.getAllDependencyConstraints()
+                .findAll { isSnapshot(it) }
+                .collect { toFullVersion(it) }
+            allDependenciesVersions.addAll(versions)
         }
-        allDependenciesVersions = allDependenciesVersions.unique()
         allDependenciesVersions.removeAll(projectVersions)
         return allDependenciesVersions
     }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/SnapshotDependenciesChecker.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/SnapshotDependenciesChecker.groovy
@@ -1,20 +1,28 @@
 package pl.allegro.tech.build.axion.release.domain
 
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.DependencyConstraint
 
 class SnapshotDependenciesChecker {
 
     Collection<String> snapshotVersions(Project project) {
-        Collection<String> projectVersions = project.rootProject.allprojects.collect {toFullVersion(it)}
-        Collection<String> allDependenciesVersions = project.allprojects.collect {
-            it.configurations.collect { config ->
-                config.allDependencies.findAll {isSnapshot(it)}.collect {toFullVersion(it)}+
-                    config.allDependencyConstraints.findAll {isSnapshot(it)}.collect {toFullVersion(it)}
-
+        Collection<String> projectVersions = project.getRootProject().getAllprojects()
+            .collect { toFullVersion(it) }
+        Collection<String> allDependenciesVersions = []
+        for (final Project proj in project.getRootProject().getAllprojects()) {
+            for (Configuration config : proj.getConfigurations()) {
+                Collection<String> versions = config.getAllDependencies()
+                    .findAll { isSnapshot(it) }
+                    .collect { toFullVersion(it) }
+                +config.getAllDependencyConstraints()
+                    .findAll { isSnapshot(it) }
+                    .collect { toFullVersion(it) }
+                allDependenciesVersions.addAll(versions)
             }
-        }.flatten().unique()
+        }
+        allDependenciesVersions = allDependenciesVersions.unique()
         allDependenciesVersions.removeAll(projectVersions)
         return allDependenciesVersions
     }
@@ -22,6 +30,7 @@ class SnapshotDependenciesChecker {
     boolean isSnapshot(Dependency dependency) {
         dependency.version?.endsWith("-SNAPSHOT")
     }
+
     boolean isSnapshot(DependencyConstraint dependency) {
         dependency.version?.endsWith("-SNAPSHOT")
     }


### PR DESCRIPTION
Hi, this helps to avoid ConcurrentModificationException in SnapshotDependenciesChecker.snapshotVersions.
Related issue https://github.com/allegro/axion-release-plugin/issues/818
