### PR TITLE
Ignore non-semver tags

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@ root = true
 [*]
 indent_style = space
 indent_size = 4
+ij_continuation_indent_size = 4
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionResolver.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionResolver.java
@@ -70,9 +70,9 @@ public class VersionResolver {
 
         List<Pattern> releaseTagPatterns = tagProperties.getAllPrefixes().stream()
             .map(prefix -> prefix.isEmpty() ? "" : prefix + tagProperties.getVersionSeparator())
-            .map(pattern -> Pattern.compile("^" + pattern + ".*"))
+            .map(pattern -> Pattern.compile("^" + pattern + "(.+)\\.(.+)\\.(.+)"))
             .collect(toList());
-        Pattern nextVersionTagPattern = Pattern.compile(".*" + nextVersionProperties.getSuffix() + "$");
+        Pattern nextVersionTagPattern = Pattern.compile("(.+)\\.(.+)\\.(.+)" + nextVersionProperties.getSuffix() + "$");
         boolean forceSnapshot = versionProperties.isForceSnapshot();
         boolean useHighestVersion = versionProperties.isUseHighestVersion();
 


### PR DESCRIPTION
I'm not sure if it's worth to hide this behavior under a config property - the only difference is that the plugin won't fail in some cases and just ignore the non-semver tags