### PR TITLE
Make -Prelease.overriddenBranchName work in non-detached state

### DIFF
--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepository.java
@@ -387,7 +387,7 @@ public class GitRepository implements ScmRepository {
                 .map(Repository::shortenRefName)
                 .orElse(null);
 
-            if ("HEAD".equals(branchName) && properties.getOverriddenBranchName() != null && !properties.getOverriddenBranchName().isEmpty()) {
+            if (properties.getOverriddenBranchName() != null && !properties.getOverriddenBranchName().isEmpty()) {
                 branchName = Repository.shortenRefName(properties.getOverriddenBranchName());
             }
             return branchName;

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitRepositoryTest.groovy
@@ -367,7 +367,7 @@ class GitRepositoryTest extends Specification {
         position.branch == 'feature/overridden-branch-name'
     }
 
-    def "should ignore overriddenBranchName when not in detached state"() {
+    def "should not ignore overriddenBranchName when not in detached state"() {
         given:
         File repositoryDir = File.createTempDir('axion-release', 'tmp')
         def scmProperties = scmProperties(repositoryDir)
@@ -384,7 +384,7 @@ class GitRepositoryTest extends Specification {
         ScmPosition position = repository.currentPosition()
 
         then:
-        position.branch == 'some-branch'
+        position.branch == 'feature/overridden-branch-name'
     }
 
     def "should push changes and tag to remote"() {


### PR DESCRIPTION
Make -Prelease.overriddenBranchName work in non-detached state

As per https://github.com/allegro/axion-release-plugin/issues/885

Tested it locally and it worked.