### PR TITLE
Quieten down the 'not on release branch' info and add '[disabled]' descriptor to the disabled release tasks

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -119,11 +119,14 @@ abstract class ReleasePlugin implements Plugin<Project> {
             currentBranch,
             String.join(",", releaseBranchNames)
         )
-        project.logger.lifecycle(message);
+        project.logger.info(message);
 
         List<String> tasksToDisable = [RELEASE_TASK, CREATE_RELEASE_TASK, PUSH_RELEASE_TASK, VERIFY_RELEASE_TASK]
         project.tasks
             .matching { it.name in tasksToDisable }
-            .configureEach { it.enabled = false }
+            .configureEach {
+                it.enabled = false
+                it.description = "[disabled] ${it.description}"
+            }
     }
 }


### PR DESCRIPTION
When the `releaseOnlyOnReleaseBranches` option is set and you're not on a release branch, this message gets printed on every time gradle is run.

This is unnecessarily noisy and adds unnecessary clunk to the log output of gradle tasks. It's better to have it logged on `info` level and optionally add the `[disabled]` tag to each of the tasks.