### PR TITLE
Fix IllegalStateException when plugin is applied in pluginManagement

### DIFF
--- a/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/ReleasePlugin.groovy
@@ -30,7 +30,15 @@ abstract class ReleasePlugin implements Plugin<Project> {
         Gradle rootGradle = project.gradle
         while(rootGradle.parent != null) { rootGradle = rootGradle.parent }
 
-        VersionConfig versionConfig = project.extensions.create(VERSION_EXTENSION, VersionConfig, rootGradle.rootProject.layout.projectDirectory)
+        def projectDirectory
+        try {
+            projectDirectory = rootGradle.rootProject.layout.projectDirectory
+        } catch (IllegalStateException ignored) {
+            // root project not yet available when applied inside pluginManagement { includeBuild() }
+            projectDirectory = project.rootProject.layout.projectDirectory
+        }
+
+        VersionConfig versionConfig = project.extensions.create(VERSION_EXTENSION, VersionConfig, projectDirectory)
 
         project.tasks.withType(BaseAxionTask).configureEach({
             it.versionConfig = versionConfig


### PR DESCRIPTION
Wrap the rootGradle.rootProject access in a try/catch. When the root project is not yet available, fall back to project.rootProject.layout.projectDirectory — the local included build's own root, which is always available at this stage.