### PR TITLE
Bump org.bouncycastle:bcprov-jdk18on from 1.82 to 1.84

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ sourceSets {
 dependencies {
     api(localGroovy())
     runtimeOnly(libs.bundles.jgit.runtime)
-    runtimeOnly("org.bouncycastle:bcprov-jdk18on:1.82")
+    runtimeOnly("org.bouncycastle:bcprov-jdk18on:1.84")
     runtimeOnly("com.kohlschutter.junixsocket:junixsocket-core:2.9.1")
     runtimeOnly("net.java.dev.jna:jna-platform:5.19.1")
 


### PR DESCRIPTION
Bumps bcprov-jdk18on to the latest version to fix security vulnerabilities:
CVE-2026-5598
CVE-2026-0636
CVE-2025-14813