### PR TITLE
Skip the working tree scan when uncommitted changes are ignored

### DIFF
--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/ScmState.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/ScmState.java
@@ -1,17 +1,30 @@
 package pl.allegro.tech.build.axion.release.domain;
 
+import java.util.function.BooleanSupplier;
+
 public class ScmState {
 
     private final boolean onReleaseTag;
     private final boolean onNextVersionTag;
     private final boolean noReleaseTagsFound;
-    private final boolean hasUncommittedChanges;
+    private final BooleanSupplier uncommittedChanges;
 
-    public ScmState(boolean onReleaseTag, boolean onNextVersionTag, boolean noReleaseTagsFound, boolean hasUncommittedChanges) {
+    private Boolean memoizedUncommittedChanges;
+
+    public ScmState(boolean onReleaseTag, boolean onNextVersionTag, boolean noReleaseTagsFound, BooleanSupplier uncommittedChanges) {
         this.onReleaseTag = onReleaseTag;
         this.onNextVersionTag = onNextVersionTag;
         this.noReleaseTagsFound = noReleaseTagsFound;
-        this.hasUncommittedChanges = hasUncommittedChanges;
+        this.uncommittedChanges = uncommittedChanges;
+    }
+
+    /**
+     * @deprecated use {@link #ScmState(boolean, boolean, boolean, BooleanSupplier)} - scanning the working tree
+     * is expensive and is not needed when uncommitted changes are ignored
+     */
+    @Deprecated
+    public ScmState(boolean onReleaseTag, boolean onNextVersionTag, boolean noReleaseTagsFound, boolean hasUncommittedChanges) {
+        this(onReleaseTag, onNextVersionTag, noReleaseTagsFound, () -> hasUncommittedChanges);
     }
 
     public final boolean isOnReleaseTag() {
@@ -27,7 +40,10 @@ public class ScmState {
     }
 
     public final boolean hasUncommittedChanges() {
-        return hasUncommittedChanges;
+        if (memoizedUncommittedChanges == null) {
+            memoizedUncommittedChanges = uncommittedChanges.getAsBoolean();
+        }
+        return memoizedUncommittedChanges;
     }
 
     @Override
@@ -36,7 +52,8 @@ public class ScmState {
             "onReleaseTag=" + onReleaseTag +
             ", onNextVersionTag=" + onNextVersionTag +
             ", noReleaseTagsFound=" + noReleaseTagsFound +
-            ", hasUncommittedChanges=" + hasUncommittedChanges +
+            // printing the state must stay cheap, so this does not force the check
+            ", hasUncommittedChanges=" + (memoizedUncommittedChanges == null ? "<not checked>" : memoizedUncommittedChanges) +
             '}';
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionResolver.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/VersionResolver.java
@@ -52,7 +52,7 @@ public class VersionResolver {
             versions.onReleaseTag,
             versions.onNextVersionTag,
             versions.noTagsFound,
-            repository.checkUncommittedChanges()
+            repository::checkUncommittedChanges
         );
 
         VersionFactory.FinalVersion finalVersion = versionFactory.createFinalVersion(scmState, versions.current);

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ScmStateBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/ScmStateBuilder.groovy
@@ -1,5 +1,7 @@
 package pl.allegro.tech.build.axion.release.domain
 
+import java.util.function.BooleanSupplier
+
 class ScmStateBuilder {
 
     private boolean onReleaseTag = false
@@ -15,7 +17,7 @@ class ScmStateBuilder {
     }
 
     ScmState build() {
-        return new ScmState(onReleaseTag, onNextVersionTag, noReleaseTagsFound, hasUncommittedChanges)
+        return new ScmState(onReleaseTag, onNextVersionTag, noReleaseTagsFound, { hasUncommittedChanges } as BooleanSupplier)
     }
 
     ScmStateBuilder onReleaseTag() {

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/VersionResolverTest.groovy
@@ -4,6 +4,7 @@ import pl.allegro.tech.build.axion.release.RepositoryBasedTest
 import pl.allegro.tech.build.axion.release.domain.properties.NextVersionProperties
 import pl.allegro.tech.build.axion.release.domain.properties.TagProperties
 import pl.allegro.tech.build.axion.release.domain.properties.VersionProperties
+import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 
 import static pl.allegro.tech.build.axion.release.TagPrefixConf.defaultPrefix
 import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullPrefix
@@ -449,5 +450,39 @@ class VersionResolverTest extends RepositoryBasedTest {
         version.previousVersion.toString() == '2.0.0'
         version.version.toString() == '2.0.0'
         !version.snapshot
+    }
+
+    def "should not scan working tree for uncommitted changes when they are ignored"() {
+        given:
+        repository.tag(fullPrefix() + '1.1.0')
+        repository.commit(['*'], 'some commit')
+
+        CountingRepository ignoring = new CountingRepository(repository)
+        CountingRepository checking = new CountingRepository(repository)
+
+        when:
+        new VersionResolver(ignoring, "").resolveVersion(versionProperties().build(), tagRules, nextVersionRules)
+        new VersionResolver(checking, "").resolveVersion(versionProperties().dontIgnoreUncommittedChanges().build(), tagRules, nextVersionRules)
+
+        then: 'the only difference is the single check VersionFactory short-circuits away'
+        checking.uncommittedChangesChecks == ignoring.uncommittedChangesChecks + 1
+    }
+
+    static class CountingRepository implements ScmRepository {
+
+        @Delegate
+        private final ScmRepository delegate
+
+        int uncommittedChangesChecks = 0
+
+        CountingRepository(ScmRepository delegate) {
+            this.delegate = delegate
+        }
+
+        @Override
+        boolean checkUncommittedChanges() {
+            uncommittedChangesChecks++
+            return delegate.checkUncommittedChanges()
+        }
     }
 }


### PR DESCRIPTION
### Problem

`VersionResolver` builds `ScmState` with an eager call:

```java
new ScmState(..., repository.checkUncommittedChanges())
```

but `VersionFactory` only ever uses it behind a guard:

```java
boolean hasUncommittedChanges =
    !versionProperties.isIgnoreUncommittedChanges() && scmState.hasUncommittedChanges();
```

`ignoreUncommittedChanges` defaults to `true`, so on a default build the working tree scan is computed and immediately thrown away. `&&` would short-circuit it if the value were lazy.

That scan is `jgitRepository.status().call()`, which stats the whole working tree. On a large repository it is one of the most expensive things axion does during configuration.

### Change

`ScmState` now holds a memoized `BooleanSupplier` instead of a `boolean`, and `VersionResolver` passes `repository::checkUncommittedChanges`. Nothing else changes: the value is still computed at most once, and still computed eagerly whenever `ignoreUncommittedChanges = false`.

`toString()` deliberately does not force the check, so logging the state stays cheap.

### Compatibility

The `boolean` constructor is kept and `@Deprecated`, delegating to the supplier one, so existing source and binary callers keep working.

One visible side effect: with `ignoreUncommittedChanges = true` (the default), `ScmRepository.checkUncommittedChanges()` is no longer called during version resolution at all. In `--dry-run`, `NoOpRepository`'s `"uncommitted changes: ..."` log line therefore no longer appears in that case. Happy to keep the call if you consider that log part of the contract, but it seemed like the point of the change.

### Measurements

Isolated benchmark against a 1 GB pack / 169,177 commit / 745 tag repository, resolving `currentVersion` with a warm daemon, alternating runs:

| | before | after |
|---|---|---|
| configuration time | 30.6s | **24.5s** |
| working tree scans per resolution | 14 | **10** |

The remaining 10 come from `currentPosition()` computing `isClean` eagerly; that is a separate discussion since `isClean` is a user-visible `@Input`.

### Tests

`VersionResolverTest` asserts the difference rather than an absolute count, because `currentPosition()` also calls the method:

```groovy
checking.uncommittedChangesChecks == ignoring.uncommittedChangesChecks + 1
```
