### PR TITLE
Optional native git backend for read operations on large repositories

### DIFF
--- a/docs/configuration/repository.md
+++ b/docs/configuration/repository.md
@@ -44,4 +44,27 @@ you do not want to set this in your build script:
 The command line flag **will** override the build script even if the
 script has explicitly set the `pushTagsOnly` flag to false.
 
+## Repository backend
+
+By default `axion-release` reads the repository with **JGit**. On very
+large repositories the tag walk and the working tree status scan
+performed during configuration can take seconds. In that case you can
+switch reads to the native `git` executable:
+
+    scmVersion {
+        repository {
+            backend.set("nativeGit")
+        }
+    }
+
+A command line flag, `release.scmBackend`, is also available:
+
+    ./gradlew currentVersion -Prelease.scmBackend=nativeGit
+
+Only reads use the `git` executable. Tagging, committing, fetching and
+pushing still go through JGit, so authorization keeps working exactly
+the same way - see [authorization](authorization.md).
+
+The native backend requires `git` to be available on `PATH`.
+
 See [authorization](authorization.md) for authorization options.

--- a/src/integration/groovy/pl/allegro/tech/build/axion/release/ScmBackendIntegrationTest.groovy
+++ b/src/integration/groovy/pl/allegro/tech/build/axion/release/ScmBackendIntegrationTest.groovy
@@ -1,0 +1,51 @@
+package pl.allegro.tech.build.axion.release
+
+import org.gradle.testkit.runner.TaskOutcome
+
+class ScmBackendIntegrationTest extends BaseIntegrationTest {
+
+    def "should resolve version with native git backend configured in build file"() {
+        given:
+        buildFile('''
+            scmVersion {
+                repository {
+                    backend = 'nativeGit'
+                }
+            }
+        ''')
+
+        runGradle('release', '-Prelease.version=1.0.0', '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle('currentVersion')
+
+        then:
+        result.output.contains('1.0.0')
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "should resolve version with native git backend configured by gradle property"() {
+        given:
+        buildFile('')
+
+        runGradle('release', '-Prelease.version=1.0.0', '-Prelease.localOnly', '-Prelease.disableChecks')
+
+        when:
+        def result = runGradle('currentVersion', '-Prelease.scmBackend=nativeGit')
+
+        then:
+        result.output.contains('1.0.0')
+        result.task(":currentVersion").outcome == TaskOutcome.SUCCESS
+    }
+
+    def "should fail on unknown backend"() {
+        given:
+        buildFile('')
+
+        when:
+        def result = runGradleAndFail('currentVersion', '-Prelease.scmBackend=mercurial')
+
+        then:
+        result.output.contains("Unsupported scm backend 'mercurial'")
+    }
+}

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/RepositoryConfig.groovy
@@ -10,6 +10,7 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
+import pl.allegro.tech.build.axion.release.domain.scm.ScmBackend
 
 import javax.inject.Inject
 
@@ -26,6 +27,7 @@ abstract class RepositoryConfig extends BaseExtension {
     private static final String OVERRIDDEN_IS_CLEAN = 'release.overriddenIsClean'
     private static final String DISABLE_SSH_AGENT = 'release.disableSshAgent'
     private static final String FETCH_TAGS_PROPERTY = 'release.fetchTags'
+    private static final String SCM_BACKEND_PROPERTY = 'release.scmBackend'
 
 
     @Inject
@@ -33,6 +35,7 @@ abstract class RepositoryConfig extends BaseExtension {
         pushTagsOnly.convention(false)
         type.convention("git")
         remote.convention("origin")
+        backend.convention(ScmBackend.JGIT.id)
 
         customUsername.convention(gradleProperty(USERNAME_PROPERTY))
         customPassword.convention(gradleProperty(PASSWORD_PROPERTY))
@@ -79,6 +82,17 @@ abstract class RepositoryConfig extends BaseExtension {
     @Input
     @Optional
     abstract Property<Boolean> getPushTagsOnly()
+
+    /**
+     * Implementation used to read from the repository: 'jgit' (default) or 'nativeGit'.
+     */
+    @Input
+    @Optional
+    abstract Property<String> getBackend()
+
+    Provider<String> backend() {
+        gradleProperty(SCM_BACKEND_PROPERTY).orElse(backend)
+    }
 
     Provider<Boolean> pushTagsOnly() {
         gradlePropertyPresent(RELEASE_PUSH_TAGS_ONLY_PROPERTY).orElse(pushTagsOnly)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/domain/VersionConfig.groovy
@@ -5,6 +5,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.provider.MapProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
@@ -58,6 +59,14 @@ abstract class VersionConfig extends BaseExtension {
 
     @Nested
     final RepositoryConfig repository
+
+    /**
+     * Needed by scm backends that shell out and therefore have to go through Gradle's exec provider.
+     */
+    @Internal
+    ProviderFactory getProviderFactory() {
+        return providers
+    }
 
     @Nested
     final TagNameSerializationConfig tag = objects.newInstance(TagNameSerializationConfig)

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/config/ScmPropertiesFactory.groovy
@@ -2,6 +2,7 @@ package pl.allegro.tech.build.axion.release.infrastructure.config
 
 
 import pl.allegro.tech.build.axion.release.domain.VersionConfig
+import pl.allegro.tech.build.axion.release.domain.scm.ScmBackend
 import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties
 
 class ScmPropertiesFactory {
@@ -21,7 +22,9 @@ class ScmPropertiesFactory {
             config.getReleaseBranchNames().get(),
             config.getReleaseOnlyOnReleaseBranches().get(),
             config.getIgnoreGlobalGitConfig().get(),
-            config.tag.prefix.get()
+            config.tag.prefix.get(),
+            ScmBackend.of(config.repository.backend().getOrNull()),
+            config.providerFactory
         )
     }
 }

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactory.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/ScmRepositoryFactory.groovy
@@ -2,11 +2,13 @@ package pl.allegro.tech.build.axion.release.infrastructure.di
 
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
+import pl.allegro.tech.build.axion.release.domain.scm.ScmBackend
 import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository
 import pl.allegro.tech.build.axion.release.domain.scm.ScmRepositoryUnavailableException
 import pl.allegro.tech.build.axion.release.infrastructure.DummyRepository
 import pl.allegro.tech.build.axion.release.infrastructure.git.GitRepository
+import pl.allegro.tech.build.axion.release.infrastructure.git.NativeGitRepository
 
 class ScmRepositoryFactory {
     private static final Logger logger = Logging.getLogger(ScmRepositoryFactory.class);
@@ -20,7 +22,11 @@ class ScmRepositoryFactory {
 
         ScmRepository repository
         try {
-            repository = new GitRepository(properties)
+            GitRepository jgitRepository = new GitRepository(properties)
+            // the native backend only takes over reads, writes stay on JGit to keep transport auth unchanged
+            repository = properties.backend == ScmBackend.NATIVE
+                ? new NativeGitRepository(properties, jgitRepository)
+                : jgitRepository
         } catch (ScmRepositoryUnavailableException exception) {
             logger.warn("Failed to open repository, trying to work without it $exception.message")
             repository = new DummyRepository()

--- a/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/VersionResolutionContext.groovy
+++ b/src/main/groovy/pl/allegro/tech/build/axion/release/infrastructure/di/VersionResolutionContext.groovy
@@ -14,6 +14,7 @@ import pl.allegro.tech.build.axion.release.infrastructure.config.RulesFactory
 import pl.allegro.tech.build.axion.release.infrastructure.config.ScmPropertiesFactory
 import pl.allegro.tech.build.axion.release.infrastructure.git.GitChangesPrinter
 import pl.allegro.tech.build.axion.release.infrastructure.git.GitRepository
+import pl.allegro.tech.build.axion.release.infrastructure.git.NativeGitRepository
 
 class VersionResolutionContext {
 
@@ -80,6 +81,12 @@ class VersionResolutionContext {
     }
 
     ScmChangesPrinter changesPrinter() {
-        return new GitChangesPrinter(scmRepository as GitRepository)
+        return new GitChangesPrinter(jgitRepository())
+    }
+
+    private GitRepository jgitRepository() {
+        return (scmRepository instanceof NativeGitRepository
+            ? ((NativeGitRepository) scmRepository).writeDelegate
+            : scmRepository) as GitRepository
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmBackend.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmBackend.java
@@ -1,0 +1,44 @@
+package pl.allegro.tech.build.axion.release.domain.scm;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+/**
+ * Selects the implementation used to read from the SCM.
+ */
+public enum ScmBackend {
+
+    /**
+     * Pure Java implementation, used by default.
+     */
+    JGIT("jgit"),
+
+    /**
+     * Native {@code git} executable. Only reads are executed natively, writes still go through JGit.
+     */
+    NATIVE("nativeGit");
+
+    private final String id;
+
+    ScmBackend(String id) {
+        this.id = id;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public static ScmBackend of(String value) {
+        if (value == null || value.isBlank()) {
+            return JGIT;
+        }
+        String normalized = value.trim();
+        return Arrays.stream(values())
+            .filter(backend -> backend.id.equalsIgnoreCase(normalized) || backend.name().equalsIgnoreCase(normalized))
+            .findFirst()
+            .orElseThrow(() -> new IllegalArgumentException(
+                "Unsupported scm backend '" + value + "', supported values: "
+                    + Arrays.stream(values()).map(ScmBackend::getId).collect(Collectors.joining(", "))
+            ));
+    }
+}

--- a/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmProperties.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/domain/scm/ScmProperties.java
@@ -1,5 +1,7 @@
 package pl.allegro.tech.build.axion.release.domain.scm;
 
+import org.gradle.api.provider.ProviderFactory;
+
 import java.io.File;
 import java.util.Optional;
 import java.util.Set;
@@ -21,6 +23,8 @@ public class ScmProperties {
     private final boolean releaseOnlyOnReleaseBranches;
     private final boolean ignoreGlobalGitConfig;
     private final String tagPrefix;
+    private final ScmBackend backend;
+    private final ProviderFactory providers;
 
     public ScmProperties(
         String type,
@@ -37,7 +41,9 @@ public class ScmProperties {
         Set<String> releaseBranchNames,
         boolean releaseOnlyOnReleaseBranches,
         boolean ignoreGlobalGitConfig,
-        String tagPrefix
+        String tagPrefix,
+        ScmBackend backend,
+        ProviderFactory providers
     ) {
         this.type = type;
         this.directory = directory;
@@ -54,6 +60,8 @@ public class ScmProperties {
         this.releaseOnlyOnReleaseBranches = releaseOnlyOnReleaseBranches;
         this.ignoreGlobalGitConfig = ignoreGlobalGitConfig;
         this.tagPrefix = tagPrefix;
+        this.backend = backend == null ? ScmBackend.JGIT : backend;
+        this.providers = providers;
     }
 
     public ScmPushOptions pushOptions() {
@@ -118,5 +126,16 @@ public class ScmProperties {
 
     public String tagPrefix() {
         return tagPrefix;
+    }
+
+    public ScmBackend getBackend() {
+        return backend;
+    }
+
+    /**
+     * Used by backends that shell out, so that they stay configuration cache compatible.
+     */
+    public ProviderFactory getProviders() {
+        return providers;
     }
 }

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepository.java
@@ -44,16 +44,24 @@ public class NativeGitRepository implements ScmRepository {
 
     private static final String NULL_DEVICE = ProcessBuilder.Redirect.DISCARD.file().getPath();
 
+    private static final int DEFAULT_WALK_CHUNK_SIZE = 2000;
+
     private final File repositoryDir;
     private final ScmProperties properties;
     private final ScmRepository writeDelegate;
     private final ProviderFactory providers;
+    private final int walkChunkSize;
 
     public NativeGitRepository(ScmProperties properties, ScmRepository writeDelegate) {
+        this(properties, writeDelegate, DEFAULT_WALK_CHUNK_SIZE);
+    }
+
+    NativeGitRepository(ScmProperties properties, ScmRepository writeDelegate, int walkChunkSize) {
         this.properties = properties;
         this.repositoryDir = properties.getDirectory();
         this.writeDelegate = writeDelegate;
         this.providers = properties.getProviders();
+        this.walkChunkSize = walkChunkSize;
     }
 
     @Override
@@ -200,17 +208,38 @@ public class NativeGitRepository implements ScmRepository {
 
     /**
      * Commits are emitted in commit date order, which is what JGit's {@code RevSort.NONE} walk does as well.
+     * <p>
+     * The answer is normally a handful of commits away from the start, so a bounded first pass avoids reading
+     * the whole history. Falling back to the full walk keeps the result identical to an unbounded one.
      *
      * @param inclusive when false the starting commit itself is skipped
      * @param visitor   returns false to stop the walk
      */
     private void walkCommits(String startingCommit, boolean inclusive, Predicate<String> visitor) {
-        List<String> commits = lines(git(Arrays.asList("rev-list", startingCommit)));
-        for (int i = inclusive ? 0 : 1; i < commits.size(); i++) {
+        List<String> chunk = revList(startingCommit, walkChunkSize);
+        boolean historyExhausted = chunk.size() < walkChunkSize;
+
+        if (!visit(chunk, inclusive ? 0 : 1, visitor) || historyExhausted) {
+            return;
+        }
+
+        visit(revList(startingCommit, 0), chunk.size(), visitor);
+    }
+
+    private boolean visit(List<String> commits, int fromIndex, Predicate<String> visitor) {
+        for (int i = fromIndex; i < commits.size(); i++) {
             if (!visitor.test(commits.get(i))) {
-                return;
+                return false;
             }
         }
+        return true;
+    }
+
+    private List<String> revList(String startingCommit, int maxCount) {
+        List<String> arguments = maxCount > 0
+            ? Arrays.asList("rev-list", "--max-count=" + maxCount, startingCommit)
+            : Arrays.asList("rev-list", startingCommit);
+        return lines(git(arguments));
     }
 
     @Override

--- a/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepository.java
+++ b/src/main/java/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepository.java
@@ -1,0 +1,441 @@
+package pl.allegro.tech.build.axion.release.infrastructure.git;
+
+import org.gradle.api.provider.ProviderFactory;
+import org.gradle.process.ExecOutput;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmException;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmProperties;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushOptions;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPushResult;
+import pl.allegro.tech.build.axion.release.domain.scm.ScmRepository;
+import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullLegacyPrefix;
+
+/**
+ * {@link ScmRepository} that reads through the native {@code git} executable.
+ * <p>
+ * Only reads are native - on big repositories the JGit tag walk and status scan dominate configuration time.
+ * Writes (tag/push/fetch/commit/remote) are delegated to a JGit backed repository so that transport
+ * authentication driven by {@link ScmIdentity} keeps working unchanged.
+ */
+public class NativeGitRepository implements ScmRepository {
+
+    private static final String GIT_TAG_PREFIX = "refs/tags/";
+
+    /**
+     * {@code %(*objectname)} is empty for lightweight tags and holds the peeled commit for annotated ones.
+     */
+    private static final String TAG_FORMAT = "--format=%(objectname) %(*objectname) %(refname:strip=2)";
+
+    private static final String NULL_DEVICE = ProcessBuilder.Redirect.DISCARD.file().getPath();
+
+    private final File repositoryDir;
+    private final ScmProperties properties;
+    private final ScmRepository writeDelegate;
+    private final ProviderFactory providers;
+
+    public NativeGitRepository(ScmProperties properties, ScmRepository writeDelegate) {
+        this.properties = properties;
+        this.repositoryDir = properties.getDirectory();
+        this.writeDelegate = writeDelegate;
+        this.providers = properties.getProviders();
+    }
+
+    @Override
+    public ScmPosition currentPosition() {
+        String revision = getRevision();
+        String branchName = branchName();
+        boolean isClean = !checkUncommittedChanges();
+        boolean isReleaseBranch = properties.getReleaseBranchNames() != null && properties.getReleaseBranchNames().contains(branchName);
+        return new ScmPosition(revision, branchName, isClean, isReleaseBranch);
+    }
+
+    @Override
+    public ScmPosition positionOfLastChangeIn(String path, List<String> excludeSubFolders, Set<String> dependenciesFolders) {
+        List<String> arguments = new ArrayList<>(Arrays.asList("log", "--max-count=1", "--format=%H"));
+
+        // if the path is empty ('') then it means we are at the root of the Git directory
+        // in which case, we should exclude changes that occurred in subdirectory projects when deciding on
+        // which is the latest change that is relevant to the root project
+        if (path.isEmpty()) {
+            if (!excludeSubFolders.isEmpty()) {
+                arguments.add("--");
+                arguments.add(".");
+                for (String excludedPath : excludeSubFolders) {
+                    arguments.add(":(exclude)" + asUnixPath(excludedPath));
+                }
+            }
+        } else {
+            String unixStylePath = asUnixPath(path);
+            assertPathExists(unixStylePath);
+            arguments.add("--");
+            arguments.add(unixStylePath);
+            for (String dependencyFolder : dependenciesFolders) {
+                arguments.add(asUnixPath(dependencyFolder));
+            }
+        }
+
+        String lastCommit = git(arguments);
+        ScmPosition currentPosition = currentPosition();
+
+        if (lastCommit.isEmpty()) {
+            return currentPosition;
+        }
+
+        return new ScmPosition(
+            lastCommit,
+            currentPosition.getBranch(),
+            currentPosition.getIsClean(),
+            currentPosition.getIsReleaseBranch()
+        );
+    }
+
+    @Override
+    public Boolean isIdenticalForPath(String path, String latestChangeRevision, String tagCommitRevision) {
+        if (latestChangeRevision.isEmpty() || tagCommitRevision.isEmpty()) {
+            return false;
+        }
+        if (latestChangeRevision.equals(tagCommitRevision)) {
+            return true;
+        }
+
+        List<String> arguments = new ArrayList<>(Arrays.asList("diff", "--quiet", latestChangeRevision, tagCommitRevision));
+        if (path != null && !path.isEmpty()) {
+            arguments.add("--");
+            arguments.add(asUnixPath(path));
+        }
+
+        ProcessOutput output = run(arguments);
+        if (output.exitCode == 0) {
+            return true;
+        }
+        if (output.exitCode == 1) {
+            return false;
+        }
+        throw failure(arguments, output);
+    }
+
+    @Override
+    public TagsOnCommit latestTags(List<Pattern> patterns) {
+        return latestTagsInternal(patterns, null, true);
+    }
+
+    @Override
+    public TagsOnCommit latestTags(List<Pattern> patterns, String sinceCommit) {
+        return latestTagsInternal(patterns, sinceCommit, false);
+    }
+
+    @Override
+    public List<TagsOnCommit> taggedCommits(List<Pattern> patterns) {
+        return taggedCommitsInternal(patterns, null, true, false);
+    }
+
+    private TagsOnCommit latestTagsInternal(List<Pattern> patterns, String maybeSinceCommit, boolean inclusive) {
+        List<TagsOnCommit> taggedCommits = taggedCommitsInternal(patterns, maybeSinceCommit, inclusive, true);
+        return taggedCommits.isEmpty() ? TagsOnCommit.empty() : taggedCommits.get(0);
+    }
+
+    private List<TagsOnCommit> taggedCommitsInternal(
+        List<Pattern> patterns,
+        String maybeSinceCommit,
+        boolean inclusive,
+        boolean stopOnFirstTag
+    ) {
+        List<TagsOnCommit> taggedCommits = new ArrayList<>();
+
+        Map<String, List<String>> allTags = tagsMatching(patterns);
+        if (allTags.isEmpty() || !hasCommits()) {
+            return taggedCommits;
+        }
+
+        String startingCommit = maybeSinceCommit == null ? "HEAD" : maybeSinceCommit;
+        walkCommits(startingCommit, inclusive, commitId -> {
+            List<String> tagsOnCommit = allTags.get(commitId);
+            if (tagsOnCommit == null) {
+                return true;
+            }
+            taggedCommits.add(new TagsOnCommit(commitId, tagsOnCommit));
+            return !stopOnFirstTag;
+        });
+
+        return taggedCommits;
+    }
+
+    /**
+     * Peeled commit id to matching tag names. {@code for-each-ref} sorts by ref name, same as JGit's tag list.
+     */
+    private Map<String, List<String>> tagsMatching(List<Pattern> patterns) {
+        Map<String, List<String>> tags = new HashMap<>();
+
+        for (String line : lines(git(Arrays.asList("for-each-ref", TAG_FORMAT, "refs/tags")))) {
+            String[] parts = line.split(" ", 3);
+            if (parts.length < 3) {
+                continue;
+            }
+            String name = parts[2];
+            if (patterns.stream().noneMatch(pattern -> pattern.matcher(name).matches())) {
+                continue;
+            }
+            String commitId = parts[1].isEmpty() ? parts[0] : parts[1];
+            tags.computeIfAbsent(commitId, id -> new ArrayList<>()).add(name);
+        }
+
+        return tags;
+    }
+
+    /**
+     * Commits are emitted in commit date order, which is what JGit's {@code RevSort.NONE} walk does as well.
+     *
+     * @param inclusive when false the starting commit itself is skipped
+     * @param visitor   returns false to stop the walk
+     */
+    private void walkCommits(String startingCommit, boolean inclusive, Predicate<String> visitor) {
+        List<String> commits = lines(git(Arrays.asList("rev-list", startingCommit)));
+        for (int i = inclusive ? 0 : 1; i < commits.size(); i++) {
+            if (!visitor.test(commits.get(i))) {
+                return;
+            }
+        }
+    }
+
+    @Override
+    public boolean remoteAttached(String remoteName) {
+        return lines(git(Collections.singletonList("remote"))).contains(remoteName);
+    }
+
+    /**
+     * @return true when there are uncommitted changes. This means: not clean
+     */
+    @Override
+    public boolean checkUncommittedChanges() {
+        Optional<Boolean> overriddenIsClean = properties.getOverriddenIsClean();
+        if (overriddenIsClean.isPresent()) {
+            // the logic to get the isClean-property is inverted
+            return !overriddenIsClean.get();
+        }
+        return !git(Arrays.asList("status", "--porcelain")).isEmpty();
+    }
+
+    @Override
+    public int numberOfCommitsAheadOrBehindRemote() {
+        ProcessOutput upstream = run(Arrays.asList("rev-parse", "--symbolic-full-name", "@{upstream}"));
+        if (upstream.exitCode != 0 || upstream.standardOutput.trim().isEmpty()) {
+            throw new ScmException("Branch " + fullBranchName() + " is not set to track another branch");
+        }
+
+        String range = upstream.standardOutput.trim() + "...HEAD";
+        String[] counts = git(Arrays.asList("rev-list", "--left-right", "--count", range)).split("\\s+");
+        int behind = Integer.parseInt(counts[0]);
+        int ahead = Integer.parseInt(counts[1]);
+
+        if (ahead > 0) {
+            return ahead;
+        }
+        if (behind > 0) {
+            return -behind;
+        }
+        return 0;
+    }
+
+    @Override
+    public boolean isLegacyDefTagnameRepo() {
+        List<String> tags = lines(git(Arrays.asList("for-each-ref", "--format=%(refname)", "refs/tags")));
+        if (tags.isEmpty()) {
+            return false;
+        }
+        return tags.stream().allMatch(ref -> ref.startsWith(GIT_TAG_PREFIX + fullLegacyPrefix()));
+    }
+
+    @Override
+    public List<String> lastLogMessages(int messageCount) {
+        String messages = git(Arrays.asList("log", "--max-count=" + messageCount, "--format=%B%x00"));
+        return Arrays.stream(messages.split("\u0000"))
+            .map(String::trim)
+            .filter(message -> !message.isEmpty())
+            .collect(Collectors.toList());
+    }
+
+    @Override
+    public void fetchTags(ScmIdentity identity, String remoteName) {
+        writeDelegate.fetchTags(identity, remoteName);
+    }
+
+    @Override
+    public void tag(String tagName, String tagMessage) {
+        writeDelegate.tag(tagName, tagMessage);
+    }
+
+    @Override
+    public void dropTag(String tagName) {
+        writeDelegate.dropTag(tagName);
+    }
+
+    @Override
+    public ScmPushResult push(ScmIdentity identity, ScmPushOptions pushOptions) {
+        return writeDelegate.push(identity, pushOptions);
+    }
+
+    @Override
+    public void commit(List<String> patterns, String message) {
+        writeDelegate.commit(patterns, message);
+    }
+
+    @Override
+    public void attachRemote(String remoteName, String url) {
+        writeDelegate.attachRemote(remoteName, url);
+    }
+
+    public ScmRepository getWriteDelegate() {
+        return writeDelegate;
+    }
+
+    private String getRevision() {
+        ProcessOutput output = run(Arrays.asList("rev-parse", "--verify", "--quiet", "HEAD"));
+        return output.exitCode == 0 ? output.standardOutput.trim() : "";
+    }
+
+    private boolean hasCommits() {
+        return !getRevision().isEmpty();
+    }
+
+    private String branchName() {
+        return branchNameFromGithubEnvVariable().orElseGet(this::branchNameFromGit);
+    }
+
+    /**
+     * @see GitRepository for the rationale behind reading GITHUB_HEAD_REF
+     */
+    private Optional<String> branchNameFromGithubEnvVariable() {
+        if (onGithubActions()) {
+            return env("GITHUB_HEAD_REF").filter(it -> !it.isBlank());
+        }
+        return Optional.empty();
+    }
+
+    /**
+     * @return branch name or 'HEAD' when in detached state, unless it is overridden by 'overriddenBranchName'
+     */
+    private String branchNameFromGit() {
+        String overriddenBranchName = properties.getOverriddenBranchName();
+        if (overriddenBranchName != null && !overriddenBranchName.isEmpty()) {
+            return shortenRefName(overriddenBranchName);
+        }
+        // unlike 'rev-parse --abbrev-ref' this also resolves branches without any commit yet
+        ProcessOutput output = run(Arrays.asList("symbolic-ref", "--quiet", "--short", "HEAD"));
+        return output.exitCode == 0 ? output.standardOutput.trim() : "HEAD";
+    }
+
+    private String fullBranchName() {
+        ProcessOutput output = run(Arrays.asList("rev-parse", "--symbolic-full-name", "HEAD"));
+        return output.exitCode == 0 ? output.standardOutput.trim() : "HEAD";
+    }
+
+    private static String shortenRefName(String refName) {
+        if (refName.startsWith("refs/heads/")) {
+            return refName.substring("refs/heads/".length());
+        }
+        if (refName.startsWith(GIT_TAG_PREFIX)) {
+            return refName.substring(GIT_TAG_PREFIX.length());
+        }
+        if (refName.startsWith("refs/remotes/")) {
+            return refName.substring("refs/remotes/".length());
+        }
+        return refName;
+    }
+
+    private boolean onGithubActions() {
+        return env("GITHUB_ACTIONS").map(it -> it.equals("true")).orElse(false);
+    }
+
+    private Optional<String> env(String name) {
+        return Optional.ofNullable(System.getenv(name));
+    }
+
+    private String asUnixPath(String path) {
+        return path == null ? null : path.replaceAll("\\\\", "/");
+    }
+
+    private void assertPathExists(String path) {
+        File subpath = new File(repositoryDir, path);
+        if (!subpath.exists()) {
+            throw new ScmException(
+                String.format("Path '%s' does not exist in repository '%s'.",
+                    path, repositoryDir.getAbsolutePath()
+                ));
+        }
+    }
+
+    private static List<String> lines(String output) {
+        return output.isEmpty() ? Collections.emptyList() : Arrays.asList(output.split("\\R"));
+    }
+
+    private String git(List<String> arguments) {
+        ProcessOutput output = run(arguments);
+        if (output.exitCode != 0) {
+            throw failure(arguments, output);
+        }
+        return output.standardOutput.trim();
+    }
+
+    /**
+     * Uses Gradle's exec provider rather than {@link ProcessBuilder}, so that reads performed during
+     * configuration stay compatible with the configuration cache.
+     */
+    private ProcessOutput run(List<String> arguments) {
+        List<String> command = new ArrayList<>(arguments.size() + 1);
+        command.add("git");
+        command.addAll(arguments);
+
+        ExecOutput output = providers.exec(spec -> {
+            spec.setCommandLine(command);
+            spec.setWorkingDir(repositoryDir);
+            spec.setIgnoreExitValue(true);
+            // read only commands should never take index.lock, parallel builds would fight over it
+            spec.environment("GIT_OPTIONAL_LOCKS", "0");
+            if (properties.isIgnoreGlobalGitConfig()) {
+                spec.environment("GIT_CONFIG_GLOBAL", NULL_DEVICE);
+                spec.environment("GIT_CONFIG_SYSTEM", NULL_DEVICE);
+            }
+        });
+
+        return new ProcessOutput(
+            output.getResult().get().getExitValue(),
+            output.getStandardOutput().getAsText().get(),
+            output.getStandardError().getAsText().get()
+        );
+    }
+
+    private static ScmException failure(List<String> arguments, ProcessOutput output) {
+        return new ScmException(
+            "git " + String.join(" ", arguments) + " failed with exit code " + output.exitCode
+                + ": " + output.errorOutput.trim()
+        );
+    }
+
+    private static final class ProcessOutput {
+        final int exitCode;
+        final String standardOutput;
+        final String errorOutput;
+
+        ProcessOutput(int exitCode, String standardOutput, String errorOutput) {
+            this.exitCode = exitCode;
+            this.standardOutput = standardOutput;
+            this.errorOutput = errorOutput;
+        }
+    }
+}

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/domain/scm/ScmPropertiesBuilder.groovy
@@ -1,12 +1,19 @@
 package pl.allegro.tech.build.axion.release.domain.scm
 
+import org.gradle.api.provider.ProviderFactory
+import org.gradle.testfixtures.ProjectBuilder
+
 class ScmPropertiesBuilder {
+
+    // ProviderFactory is only obtainable from a Gradle project, one throwaway project per JVM is enough
+    private static final ProviderFactory PROVIDERS = ProjectBuilder.builder().build().providers
 
     private final File directory
 
     private String type = 'git'
     private String overriddenBranchName
     private Boolean overriddenIsClean = null
+    private ScmBackend backend = ScmBackend.JGIT
 
     private ScmPropertiesBuilder(File directory) {
         this.directory = directory
@@ -26,6 +33,11 @@ class ScmPropertiesBuilder {
         return this
     }
 
+    ScmPropertiesBuilder withBackend(ScmBackend backend) {
+        this.backend = backend
+        return this
+    }
+
     ScmProperties build() {
         return new ScmProperties(
             type,
@@ -42,7 +54,9 @@ class ScmPropertiesBuilder {
             ['main', 'master'] as Set,
             false,
             true,
-            'v'
+            'v',
+            backend,
+            PROVIDERS
         )
     }
 

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/GitProjectBuilder.groovy
@@ -79,7 +79,9 @@ class GitProjectBuilder {
     Map build() {
         Map map = [:]
         map[Grgit] = rawRepository
-        map[GitRepository] = new GitRepository(scmProperties)
+        GitRepository gitRepository = new GitRepository(scmProperties)
+        map[GitRepository] = gitRepository
+        map[NativeGitRepository] = new NativeGitRepository(scmProperties, gitRepository)
 
         return map
     }

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepositoryTest.groovy
@@ -200,6 +200,38 @@ class NativeGitRepositoryTest extends Specification {
         tags.tags == [fullPrefix() + '1.0.0', fullPrefix() + '2.0.0']
     }
 
+    def "should fall back to full history walk when tag is beyond the bounded walk"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+        5.times { repository.commit(['*'], "commit $it after release") }
+
+        and: 'a repository that only reads two commits per walk'
+        NativeGitRepository chunkedRepository = new NativeGitRepository(
+            scmProperties(repositoryDir).build(), jgitRepository, 2)
+
+        when:
+        TagsOnCommit tags = chunkedRepository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == [fullPrefix() + '1.0.0']
+        tags.commitId == repository.latestTags(ANY_PREFIXED_TAG).commitId
+    }
+
+    def "should stop at the nearest tag without walking the whole history"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+        repository.commit(['*'], 'commit after 1.0.0')
+        repository.tag(fullPrefix() + '2.0.0')
+        repository.commit(['*'], 'commit after 2.0.0')
+
+        and:
+        NativeGitRepository chunkedRepository = new NativeGitRepository(
+            scmProperties(repositoryDir).build(), jgitRepository, 2)
+
+        expect:
+        chunkedRepository.latestTags(ANY_PREFIXED_TAG).tags == [fullPrefix() + '2.0.0']
+    }
+
     def "should provide current branch name and commit id in position"() {
         given:
         rawRepository.checkout(branch: 'some-branch', createBranch: true)

--- a/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepositoryTest.groovy
+++ b/src/test/groovy/pl/allegro/tech/build/axion/release/infrastructure/git/NativeGitRepositoryTest.groovy
@@ -1,0 +1,530 @@
+package pl.allegro.tech.build.axion.release.infrastructure.git
+
+import org.ajoberstar.grgit.Grgit
+import org.eclipse.jgit.lib.Constants
+import pl.allegro.tech.build.axion.release.domain.scm.ScmException
+import pl.allegro.tech.build.axion.release.domain.scm.ScmIdentity
+import pl.allegro.tech.build.axion.release.domain.scm.ScmPosition
+import pl.allegro.tech.build.axion.release.domain.scm.TagsOnCommit
+import pl.allegro.tech.build.axion.release.util.WithEnvironment
+import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.util.regex.Pattern
+
+import static java.util.regex.Pattern.compile
+import static pl.allegro.tech.build.axion.release.TagPrefixConf.defaultPrefix
+import static pl.allegro.tech.build.axion.release.TagPrefixConf.fullPrefix
+import static pl.allegro.tech.build.axion.release.domain.scm.ScmPropertiesBuilder.scmProperties
+
+/**
+ * Mirrors the read path scenarios of {@link GitRepositoryTest} and asserts that the native backend
+ * returns exactly what the JGit backend returns for the same fixture repository.
+ */
+class NativeGitRepositoryTest extends Specification {
+
+    private static final List<Pattern> ANY_PREFIXED_TAG = List.of(compile('^' + defaultPrefix() + '.*'))
+
+    File repositoryDir
+
+    File remoteRepositoryDir
+
+    Grgit rawRepository
+
+    GitRepository remoteRepository
+
+    GitRepository jgitRepository
+
+    NativeGitRepository repository
+
+    String defaultBranch
+
+    void setup() {
+        remoteRepositoryDir = File.createTempDir('axion-release', 'tmp')
+        Map remoteRepositories = GitProjectBuilder.gitProject(remoteRepositoryDir).withInitialCommit().build()
+        remoteRepository = remoteRepositories[GitRepository]
+
+        repositoryDir = File.createTempDir('axion-release', 'tmp')
+        Map repositories = GitProjectBuilder.gitProject(repositoryDir, remoteRepositoryDir).build()
+
+        rawRepository = repositories[Grgit]
+        jgitRepository = repositories[GitRepository]
+        repository = repositories[NativeGitRepository]
+
+        defaultBranch = rawRepository.branch.current().name
+    }
+
+    def "should return last tag in current position in simple case"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+        repository.commit(['*'], 'commit after release')
+
+        when:
+        TagsOnCommit tags = repository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == [fullPrefix() + '1.0.0']
+        tags.commitId == jgitRepository.latestTags(ANY_PREFIXED_TAG).commitId
+    }
+
+    def "should return no tags when no commit in repository"() {
+        given:
+        NativeGitRepository commitlessRepository = GitProjectBuilder
+            .gitProject(File.createTempDir('axion-release', 'tmp'))
+            .build()[NativeGitRepository]
+
+        when:
+        TagsOnCommit tags = commitlessRepository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == []
+    }
+
+    def "should return no tags when repository has no matching tags"() {
+        given:
+        repository.tag('otherTag')
+
+        when:
+        TagsOnCommit tags = repository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == []
+    }
+
+    def "should indicate that position is on tag when latest commit is tagged"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+
+        when:
+        TagsOnCommit tags = repository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == [fullPrefix() + '1.0.0']
+        tags.commitId == rawRepository.head().id
+    }
+
+    def "should not peel lightweight tags"() {
+        given:
+        Map repositories = GitProjectBuilder.gitProject(File.createTempDir('axion-release', 'tmp'))
+            .withInitialCommit()
+            .withLightweightTag(fullPrefix() + '1.0.0')
+            .build()
+        NativeGitRepository lightweightTagRepository = repositories[NativeGitRepository]
+
+        when:
+        lightweightTagRepository.tag(fullPrefix() + '2.0.0')
+        TagsOnCommit tags = lightweightTagRepository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == [fullPrefix() + '1.0.0', fullPrefix() + '2.0.0']
+    }
+
+    def "should track back to older tag when commit was made after checking out older version"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+        repository.commit(['*'], 'commit after ' + fullPrefix() + '1')
+        repository.tag(fullPrefix() + '2.0.0')
+        repository.commit(['*'], 'commit after ' + fullPrefix() + '2')
+
+        rawRepository.checkout(branch: fullPrefix() + '1.0.0')
+        repository.commit(['*'], 'bugfix after ' + fullPrefix() + '1')
+
+        when:
+        TagsOnCommit tags = repository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == [fullPrefix() + '1.0.0']
+    }
+
+    def "should return all tagged commits matching the pattern provided"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+        repository.commit(['*'], 'commit after ' + fullPrefix() + '1')
+        repository.tag(fullPrefix() + '2.0.0')
+        repository.commit(['*'], 'commit after ' + fullPrefix() + '2')
+        repository.tag('another-tag-1')
+        repository.commit(['*'], 'commit after another-tag-1')
+        repository.commit(['*'], 'commit after another-tag-1-2')
+        repository.tag(fullPrefix() + '4')
+        repository.commit(['*'], 'commit after ' + fullPrefix() + '4')
+        repository.tag(fullPrefix() + '3')
+        repository.commit(['*'], 'commit after ' + fullPrefix() + '3')
+
+        when:
+        List<TagsOnCommit> allTaggedCommits = repository.taggedCommits(ANY_PREFIXED_TAG)
+
+        then:
+        allTaggedCommits.collect { c -> c.tags[0] } == [fullPrefix() + '3', fullPrefix() + '4', fullPrefix() + '2.0.0', fullPrefix() + '1.0.0']
+        allTaggedCommits.collect { c -> c.commitId } == jgitRepository.taggedCommits(ANY_PREFIXED_TAG).collect { c -> c.commitId }
+    }
+
+    def "should return only tags that match with prefix"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+        repository.commit(['*'], 'commit after ' + fullPrefix() + '1')
+        repository.tag('otherTag')
+
+        when:
+        TagsOnCommit tags = repository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == [fullPrefix() + '1.0.0']
+    }
+
+    def "should return latest tagged commit before the given commit id"() {
+        given:
+        repository.tag('tag-to-find')
+        repository.commit(['*'], 'some commit')
+        repository.tag('tag-to-skip')
+
+        String latestCommitId = repository.latestTags(List.of(~'^tag.*')).commitId
+
+        when:
+        TagsOnCommit tags = repository.latestTags(List.of(~'^tag.*'), latestCommitId)
+
+        then:
+        tags.tags == ['tag-to-find']
+        tags.commitId == jgitRepository.latestTags(List.of(~'^tag.*'), latestCommitId).commitId
+    }
+
+    def "should return list of tags when multiple matching tags found on same commit"() {
+        given:
+        repository.tag(fullPrefix() + '1.0.0')
+        repository.tag(fullPrefix() + '2.0.0')
+
+        when:
+        TagsOnCommit tags = repository.latestTags(ANY_PREFIXED_TAG)
+
+        then:
+        tags.tags == [fullPrefix() + '1.0.0', fullPrefix() + '2.0.0']
+    }
+
+    def "should provide current branch name and commit id in position"() {
+        given:
+        rawRepository.checkout(branch: 'some-branch', createBranch: true)
+        repository.commit(['*'], 'first commit')
+
+        when:
+        ScmPosition position = repository.currentPosition()
+
+        then:
+        position.branch == 'some-branch'
+        position.revision == rawRepository.head().id
+        position.isClean == jgitRepository.currentPosition().isClean
+    }
+
+    def "should provide current branch name as HEAD when in detached state and overriddenBranchName not set"() {
+        given:
+        checkoutDetachedHead(rawRepository)
+
+        when:
+        ScmPosition position = repository.currentPosition()
+
+        then:
+        position.branch == 'HEAD'
+    }
+
+    def "should provide current branch name from overriddenBranchName when in detached state"() {
+        given:
+        File overriddenRepositoryDir = File.createTempDir('axion-release', 'tmp')
+        def scmProperties = scmProperties(overriddenRepositoryDir)
+            .withOverriddenBranchName('refs/heads/feature/overridden-branch-name')
+            .build()
+        Map repositories = GitProjectBuilder.gitProject(overriddenRepositoryDir, remoteRepositoryDir)
+            .usingProperties(scmProperties)
+            .build()
+        checkoutDetachedHead(repositories[Grgit] as Grgit)
+
+        when:
+        ScmPosition position = (repositories[NativeGitRepository] as NativeGitRepository).currentPosition()
+
+        then:
+        position.branch == 'feature/overridden-branch-name'
+    }
+
+    def "should not ignore overriddenBranchName when not in detached state"() {
+        given:
+        File overriddenRepositoryDir = File.createTempDir('axion-release', 'tmp')
+        def scmProperties = scmProperties(overriddenRepositoryDir)
+            .withOverriddenBranchName('refs/heads/feature/overridden-branch-name')
+            .build()
+        Map repositories = GitProjectBuilder.gitProject(overriddenRepositoryDir, remoteRepositoryDir)
+            .usingProperties(scmProperties)
+            .build()
+        (repositories[Grgit] as Grgit).checkout(branch: 'some-branch', createBranch: true)
+
+        when:
+        ScmPosition position = (repositories[NativeGitRepository] as NativeGitRepository).currentPosition()
+
+        then:
+        position.branch == 'feature/overridden-branch-name'
+    }
+
+    def "should signal there are uncommitted changes"() {
+        when:
+        new File(repositoryDir, 'uncommitted').createNewFile()
+
+        then:
+        repository.checkUncommittedChanges()
+        jgitRepository.checkUncommittedChanges()
+    }
+
+    def "should not signal uncommitted changes on clean repository"() {
+        expect:
+        !repository.checkUncommittedChanges()
+    }
+
+    def "should see tags created after an earlier read"() {
+        given:
+        repository.latestTags(ANY_PREFIXED_TAG)
+
+        when:
+        repository.tag(fullPrefix() + '1.0.0')
+
+        then:
+        repository.latestTags(ANY_PREFIXED_TAG).tags == [fullPrefix() + '1.0.0']
+    }
+
+    def "should see working tree changes made after an earlier read"() {
+        given:
+        assert !repository.checkUncommittedChanges()
+
+        when:
+        new File(repositoryDir, 'uncommitted').createNewFile()
+
+        then:
+        repository.checkUncommittedChanges()
+    }
+
+    def "should respect overriddenIsClean-flag"(boolean expectedIsClean, Boolean overriddenIsCleanFlag, boolean dirtyRepository) {
+        given:
+        File overriddenRepositoryDir = File.createTempDir('axion-release', 'tmp')
+        def scmProperties = scmProperties(overriddenRepositoryDir)
+            .withOverriddenIsClean(overriddenIsCleanFlag)
+            .build()
+        Map repositories = GitProjectBuilder.gitProject(overriddenRepositoryDir, remoteRepositoryDir)
+            .usingProperties(scmProperties)
+            .build()
+
+        when:
+        def dirtyFile = Path.of(overriddenRepositoryDir.path).resolve('dirty-file')
+        if (dirtyRepository) {
+            Files.createFile(dirtyFile)
+        }
+        ScmPosition position = (repositories[NativeGitRepository] as NativeGitRepository).currentPosition()
+
+        then:
+        position.isClean == expectedIsClean
+
+        where:
+        expectedIsClean | overriddenIsCleanFlag | dirtyRepository
+        false           | false                 | false
+        true            | true                  | false
+        false           | false                 | true
+        true            | true                  | true
+        true            | null                  | false
+        false           | null                  | true
+    }
+
+    def "last position with changes in subdir should work with backslashes"() {
+        given:
+        String subdirA = 'a/aa'
+        String fileInA = "${subdirA}/foo"
+        new File(repositoryDir, subdirA).mkdirs()
+        new File(repositoryDir, fileInA).createNewFile()
+        repository.commit([fileInA], 'Add file foo in subdirA')
+        String headSubDirAChanged = rawRepository.head().id
+
+        String subdirB = 'b/ba'
+        String fileInB = "${subdirB}/bar"
+        new File(repositoryDir, subdirB).mkdirs()
+        new File(repositoryDir, fileInB).createNewFile()
+        repository.commit([fileInB], 'Add file bar in subdirB')
+
+        when:
+        ScmPosition position = repository.positionOfLastChangeIn('a\\aa', [], [].toSet())
+
+        then:
+        position.revision == headSubDirAChanged
+    }
+
+    def "last position with monorepo dependency config - change made in dependency folder"() {
+        given:
+        String importantDir = 'a/aa'
+        String dependencyDir = 'b/bb'
+        String notInterestingDir = 'c/cc'
+
+        commitFile(notInterestingDir, 'unintresting1')
+        commitFile(importantDir, 'main_dir')
+        commitFile(dependencyDir, 'dep_dir')
+        String headSubDirAChanged = rawRepository.head().id
+
+        commitFile(notInterestingDir, 'non_intresting')
+        commitFile('after/aa', 'after')
+
+        when:
+        ScmPosition position = repository.positionOfLastChangeIn(importantDir, [], [dependencyDir].toSet())
+
+        then:
+        position.revision == headSubDirAChanged
+        position.revision == jgitRepository.positionOfLastChangeIn(importantDir, [], [dependencyDir].toSet()).revision
+    }
+
+    def "last position in root should skip excluded subfolders"() {
+        given:
+        commitFile('a/aa', 'foo')
+        String headRootChanged = rawRepository.head().id
+        commitFile('excluded', 'bar')
+
+        when:
+        ScmPosition position = repository.positionOfLastChangeIn('', ['excluded'], [].toSet())
+
+        then:
+        position.revision == headRootChanged
+        position.revision == jgitRepository.positionOfLastChangeIn('', ['excluded'], [].toSet()).revision
+    }
+
+    def "should fail when asked for position of non existing path"() {
+        when:
+        repository.positionOfLastChangeIn('not-there', [], [].toSet())
+
+        then:
+        thrown(ScmException)
+    }
+
+    def "should detect identical content for path between two revisions"() {
+        given:
+        commitFile('a/aa', 'foo')
+        String taggedCommit = rawRepository.head().id
+        commitFile('b/bb', 'bar')
+        String headCommit = rawRepository.head().id
+
+        expect:
+        repository.isIdenticalForPath('a/aa', headCommit, taggedCommit)
+        !repository.isIdenticalForPath('b/bb', headCommit, taggedCommit)
+        !repository.isIdenticalForPath('a/aa', '', taggedCommit)
+        repository.isIdenticalForPath('a/aa', headCommit, headCommit)
+    }
+
+    def "should pass ahead of remote check when in sync with remote"() {
+        expect:
+        repository.numberOfCommitsAheadOrBehindRemote() == 0
+        jgitRepository.numberOfCommitsAheadOrBehindRemote() == 0
+    }
+
+    def "should report commits behind remote"() {
+        given:
+        remoteRepository.commit(['*'], 'remote commit')
+        repository.fetchTags(ScmIdentity.defaultIdentityWithoutAgents(), 'origin')
+
+        expect:
+        repository.numberOfCommitsAheadOrBehindRemote() < 0
+        repository.numberOfCommitsAheadOrBehindRemote() == jgitRepository.numberOfCommitsAheadOrBehindRemote()
+    }
+
+    def "should report commits ahead of remote"() {
+        given:
+        repository.commit(['*'], 'local commit')
+
+        expect:
+        repository.numberOfCommitsAheadOrBehindRemote() > 0
+        repository.numberOfCommitsAheadOrBehindRemote() == jgitRepository.numberOfCommitsAheadOrBehindRemote()
+    }
+
+    def "should fail ahead of remote check when on branch with no remote tracking"() {
+        given:
+        NativeGitRepository noRemoteRepository = GitProjectBuilder
+            .gitProject(File.createTempDir('axion-release', 'tmp'))
+            .withInitialCommit()
+            .build()[NativeGitRepository]
+
+        when:
+        noRemoteRepository.numberOfCommitsAheadOrBehindRemote()
+
+        then:
+        thrown(ScmException)
+    }
+
+    def "should detect remote by name"() {
+        expect:
+        repository.remoteAttached('origin')
+        !repository.remoteAttached('notThere')
+    }
+
+    def "existing legacy default tagname repo should return true on all matches"() {
+        given:
+        repository.tag('release-1')
+        repository.tag('release-9')
+
+        expect:
+        repository.isLegacyDefTagnameRepo()
+    }
+
+    def "existing legacy default tagname repo should return false on partial matches"() {
+        given:
+        repository.tag('release-1')
+        repository.tag('bla1')
+
+        expect:
+        !repository.isLegacyDefTagnameRepo()
+    }
+
+    def "existing legacy default tagname repo should return false on empty matches"() {
+        expect:
+        !repository.isLegacyDefTagnameRepo()
+    }
+
+    def "existing legacy default tagname repo should return false on current default tag matches"() {
+        given:
+        repository.tag(fullPrefix() + '1')
+
+        expect:
+        !repository.isLegacyDefTagnameRepo()
+    }
+
+    def "should return last log messages"() {
+        given:
+        repository.commit(['*'], 'release version: 3.0.0')
+
+        expect:
+        repository.lastLogMessages(1) == ['release version: 3.0.0']
+        repository.lastLogMessages(2) == jgitRepository.lastLogMessages(2)
+    }
+
+    @WithEnvironment([
+        'GITHUB_ACTIONS=true',
+        'GITHUB_HEAD_REF=pr-source-branch'
+    ])
+    def 'should get branch name on Github Actions if pull_request triggered the workflow'() {
+        when:
+        ScmPosition position = repository.currentPosition()
+
+        then:
+        position.branch == 'pr-source-branch'
+    }
+
+    @WithEnvironment([
+        'GITHUB_ACTIONS=true',
+        'GITHUB_HEAD_REF='
+    ])
+    def 'should ignore GITHUB_HEAD_REF variable if it has empty value'() {
+        when:
+        ScmPosition position = repository.currentPosition()
+
+        then:
+        position.branch == defaultBranch
+    }
+
+    private static void checkoutDetachedHead(Grgit grgit) {
+        String headCommitId = grgit.repository.jgit.repository.resolve(Constants.HEAD).name()
+        grgit.repository.jgit.checkout().setName(headCommitId).call()
+    }
+
+    private void commitFile(String subDir, String fileName) {
+        String fileInA = "${subDir}/${fileName}"
+        new File(repositoryDir, subDir).mkdirs()
+        new File(repositoryDir, fileInA).createNewFile()
+        repository.commit([fileInA], "Add file ${fileName} in ${subDir}")
+    }
+}


### PR DESCRIPTION
Closes #1075.

Follow-up to #1074, and to the two suggestions in #736 that never landed:

> *"retrieving the tags takes some time because it iterates the whole log ... maybe it is enough to partial-compute the data, only for the relevant tags"*

### What this does

Adds an **opt-in** read path backed by the native `git` executable. Default stays JGit, so there is no behaviour change unless it is switched on.

```groovy
scmVersion {
    repository {
        backend.set("nativeGit")   // default: "jgit"
    }
}
```

or `-Prelease.scmBackend=nativeGit` (works from `gradle.properties` too).

`ScmRepositoryFactory` picks the implementation. `NativeGitRepository` implements the read half of `ScmRepository` and **delegates every write to the existing JGit `GitRepository`** — `fetchTags`, `tag`, `dropTag`, `push`, `commit`, `attachRemote` are untouched.

### Why hybrid rather than a full native rewrite

A full rewrite would also have to reimplement the remote authentication `TransportConfigCallback` / `ScmIdentity` performs today (ssh keys, in-memory PGP, token auth). Relying on ambient credential and ssh config instead would be a real, security-sensitive behaviour change. All of the measured cost is in reads, so delegating writes keeps release tagging and pushing bit-for-bit identical.

### Measurements

1 GB pack, 169,177 commits, 745 tags, isolated single-module project against the same `.git`, warm daemon, alternating runs (reproducible to ~30 ms):

| | JGit | native git |
|---|---|---|
| before #1074 | 30.6s | — |
| with #1074 (current `main`) | 24.5s | — |
| this PR | — | **19.0s** |

### Notes for review

- **Configuration cache.** Reads go through `ProviderFactory.exec`, not `ProcessBuilder` — raw process execution during configuration is a hard CC failure (`external process started ...`). This is why `ScmProperties` carries a `ProviderFactory`.
- **Bounded tag walk.** `providers.exec` cannot stream, so the walk reads a bounded chunk (`rev-list --max-count=2000`) and falls back to the full history only if that chunk yields no match *and* more history exists. Exact, not approximate. On the measured repo the nearest tag is 103 commits from HEAD; the bounded call costs 0.042s vs 0.660s. A package-private constructor takes the chunk size so both paths are tested without a huge fixture.
- **Semantics preserved.** Nearest reachable tagged commit; annotated tags peeled via `%(*objectname)`; `for-each-ref` ref-name ordering matches `tagList()`; `HEAD` when detached; `overriddenBranchName`, `GITHUB_HEAD_REF`, `overriddenIsClean`, `releaseBranchNames` all honoured; `:(exclude)` pathspecs for `excludeSubFolders`.
- **Hermetic.** `GIT_CONFIG_GLOBAL` / `GIT_CONFIG_SYSTEM` neutralised when `ignoreGlobalGitConfig` is set, mirroring `SystemReaderWithoutSystemConfig`. `GIT_OPTIONAL_LOCKS=0` avoids taking `index.lock` (measured: no cost).
- **Requires** `git` on `PATH` when enabled.

### Tests

`NativeGitRepositoryTest` mirrors the read-path scenarios of `GitRepositoryTest` and additionally asserts **output parity with the JGit backend** on the same fixture repository — tags on HEAD, nearest tag after a commit, annotated vs lightweight, no tags / no commits, detached HEAD, `overriddenBranchName`, `sinceCommit` exclusivity, pattern filtering, `taggedCommits` ordering, ahead/behind, legacy tag naming, monorepo paths. `ScmBackendIntegrationTest` covers the DSL flag, the Gradle property and an unknown backend value.

### Open questions

Fully understood if this does not fit given the v2 direction in #751 — no hard feelings if you would rather not grow v1.

Two things I am happy to change:

1. **The `repository.backend` DSL property.** As offered in #1075, I can drop it entirely and gate this on `-Prelease.scmBackend` only, so the public API does not grow at all. I left it in for discoverability, but say the word and I will strip it.
2. **Caching `GitRepository` results instead**, per the discussion in #182 — that would help both backends and cut more than this does (resolving one version currently issues ~70 git operations). I did not go there because it changes staleness semantics after `release` creates a tag.
